### PR TITLE
feat: 전체 증권사 GitHub Actions 전환 + 한투/토스 fix

### DIFF
--- a/.github/workflows/scrape-all.yml
+++ b/.github/workflows/scrape-all.yml
@@ -33,6 +33,12 @@ jobs:
         run: |
           uv sync --frozen --no-cache
 
+      - name: Setup Chrome for Selenium (Koreainvestment)
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y -qq chromium-browser chromium-chromedriver 2>/dev/null || true
+          echo "Chrome: $(chromium-browser --version 2>/dev/null || google-chrome --version 2>/dev/null || echo 'not found')"
+          echo "ChromeDriver: $(chromedriver --version 2>/dev/null || echo 'not found')"
+
       - name: Show runner IP info
         run: |
           echo "=== GitHub Actions Runner IP ==="

--- a/.github/workflows/scrape-all.yml
+++ b/.github/workflows/scrape-all.yml
@@ -1,0 +1,92 @@
+name: All-Firms Scraper (GitHub Actions IP)
+
+on:
+  schedule:
+    # 한국시간 평일 08:00~18:00, 30분 간격 (UTC 기준, LS와 5분 staggered)
+    # KST 08:05 = UTC 23:05 (전날), KST 18:05 = UTC 09:05
+    - cron: '5,35 23 * * 0-4'     # KST 월~금 08:05~08:35
+    - cron: '5,35 0-8 * * 1-5'    # KST 화~토 09:05~17:35
+    - cron: '5 9 * * 1-5'         # KST 화~토 18:05
+  workflow_dispatch:  # 수동 실행
+    inputs:
+      firms:
+        description: '특정 증권사만 실행 (쉼표 구분, 빈칸=전체)'
+        required: false
+        default: ''
+      timeout:
+        description: '비동기 함수 타임아웃(초)'
+        required: false
+        default: '120'
+
+jobs:
+  scrape-all:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Set up Python + dependencies
+        run: |
+          uv sync --frozen --no-cache
+
+      - name: Show runner IP info
+        run: |
+          echo "=== GitHub Actions Runner IP ==="
+          curl -s https://api.ipify.org
+          echo ""
+          echo "================================"
+
+      - name: Run all-firms standalone scraper
+        id: scraper
+        env:
+          # GitHub Actions에서는 DB 불필요 (sqlite fallback)
+          DB_BACKEND: sqlite
+          SQLITE_DB_PATH: /tmp/telegram_standalone.db
+          # GitHub Actions 클린 IP → 프록시 불필요
+          SOCKS_PROXY_URL: ''
+          # 스크래퍼 환경
+          TZ: Asia/Seoul
+          LOG_BASE_DIR: /tmp
+          SCRAPER_STALE_DAYS: '30'
+        run: |
+          FIRMS_ARG=""
+          if [ -n "${{ github.event.inputs.firms }}" ]; then
+            FIRMS_ARG="--firms ${{ github.event.inputs.firms }}"
+          fi
+          uv run python scripts/standalone_all_scraper.py \
+            $FIRMS_ARG \
+            --timeout ${{ github.event.inputs.timeout || 120 }} \
+            > /tmp/all_result.json 2>/tmp/all_log.txt
+          echo "=== Scraper Log ==="
+          cat /tmp/all_log.txt
+
+      - name: Upload scraped JSON as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: all-scraped-data
+          path: /tmp/all_result.json
+          retention-days: 1
+          compression-level: 0
+          overwrite: true
+
+      - name: Show scraped data summary
+        run: |
+          echo "=== All-Firms Scraping Result ==="
+          python3 -c "
+          import json
+          with open('/tmp/all_result.json') as f:
+              data = json.load(f)
+          print(f'Total firms:    {data[\"total_firms\"]}')
+          print(f'Success:        {data[\"success_firms\"]}')
+          print(f'Failed:         {data[\"failed_firms\"]}')
+          print(f'Total articles: {data[\"total_articles\"]}')
+          print()
+          for firm in data['firms']:
+              status = '✓' if firm['status'] == 'success' else '✗'
+              err = f' ({firm.get(\"error\",\"\")[:50]})' if firm['status'] != 'success' else ''
+              print(f'  {status} {firm[\"name\"]}: {firm.get(\"count\",0)} articles{err}')
+          "

--- a/.github/workflows/scrape-ls.yml
+++ b/.github/workflows/scrape-ls.yml
@@ -1,0 +1,64 @@
+name: LS Scraper (GitHub Actions IP)
+
+on:
+  schedule:
+    # 한국시간 평일 08:00~18:00, 30분 간격 (UTC 기준)
+    # KST 08:00 = UTC 23:00 (전날)
+    # KST 18:00 = UTC 09:00
+    - cron: '0,30 23 * * 0-4'     # KST 월~금 08:00~08:30
+    - cron: '0,30 0-8 * * 1-5'    # KST 화~토 09:00~17:30
+    - cron: '0 9 * * 1-5'         # KST 화~토 18:00
+  workflow_dispatch:  # 수동 실행 가능
+
+jobs:
+  scrape-ls:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install aiohttp beautifulsoup4 requests urllib3
+
+      - name: Show runner IP info
+        run: |
+          echo "=== GitHub Actions Runner IP ==="
+          curl -s https://api.ipify.org
+          echo ""
+          echo "================================"
+
+      - name: Run LS standalone scraper
+        id: scraper
+        run: |
+          python3 scripts/standalone_ls_scraper.py --max-pages 2 --detail-concurrency 3 > /tmp/ls_result.json 2>/tmp/ls_log.txt
+          echo "=== Scraper Log ==="
+          cat /tmp/ls_log.txt
+
+      - name: Upload scraped JSON as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ls-scraped-data
+          path: /tmp/ls_result.json
+          retention-days: 1
+          compression-level: 0
+          overwrite: true
+
+      - name: Show scraped data summary
+        run: |
+          echo "=== LS Scraping Result ==="
+          python3 -c "
+          import json
+          with open('/tmp/ls_result.json') as f:
+              data = json.load(f)
+          print(f'Total articles: {data[\"count\"]}')
+          print(f'Resolved URLs: {data.get(\"resolved_urls\", 0)}')
+          print(f'CDN resolved:  {data.get(\"cdn_resolved\", 0)}')
+          for a in data['articles'][:5]:
+              url_status = '✓' if a.get('telegram_url') else '✗'
+              print(f'  [{a[\"board_name\"]}] {a[\"article_title\"][:60]}... ({a[\"reg_dt\"]}) {url_status}')
+          "

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,451 @@
+# SSH Reports Scraper — GitHub Actions 전환 설계 문서
+
+> **브랜치**: `feat/gh-actions-all-scrapers`
+> **날짜**: 2026-05-31
+> **목표**: 증권사 리서치 레포트 스크래핑을 서버(Docker/APScheduler)에서 GitHub Actions cron으로 이관
+
+---
+
+## 1. 배경과 동기
+
+### 1.1 기존 구조의 문제점
+
+```
+[OCI 서버] scheduler.py (APScheduler, 30분 간격)
+  └─ scraper.py
+       ├─ 24개 증권사 checkNewArticle() 호출 (동기 7 + 비동기 17)
+       ├─ DB insert (ON CONFLICT dedup)
+       ├─ enrich_data() (DBfi gate URL 복구)
+       └─ daily_send_report() (Telegram 전송)
+```
+
+**문제**:
+- **IP 차단**: OCI 서버 IP로 장기간 크롤링 → LS증권 등에서 IP 차단 (WARP 우회 필요)
+- **서버 부하**: 24개 증권사 동시 크롤링 → CPU/메모리 사용량 높음
+- **Docker 의존성**: Selenium 필요한 증권사(한국투자)는 Docker 컨테이너 필요
+- **관측성 부족**: 로그가 서버 로컬에만 존재, 실행 이력 추적 어려움
+
+### 1.2 해결 전략
+
+**GitHub Actions로 크롤링을 이관하고, 서버는 import + enrich + send만 담당.**
+
+| 측면 | 이전 | 이후 |
+|------|------|------|
+| 크롤링 실행 | OCI 서버 (고정 IP) | GitHub Actions runner (매번 새 IP) |
+| IP 차단 | SOCKS5 WARP 우회 필요 | 불필요 (클린 IP) |
+| DB insert | 크롤링 직후 동기 실행 | 서버에서 artifact import로 분리 |
+| 실행 이력 | 서버 로컬 로그 | GitHub Actions 로그 + artifact |
+| 병렬성 | asyncio.gather | GitHub Actions 자체 isolation |
+
+---
+
+## 2. 아키텍처
+
+### 2.1 전체 데이터 흐름
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    GitHub Actions                            │
+│                                                              │
+│  scrape-ls.yml          scrape-all.yml                      │
+│  (LS 전용, :00/:30)     (전체 증권사, :05/:35)              │
+│       │                       │                              │
+│       ▼                       ▼                              │
+│  standalone_ls_scraper   standalone_all_scraper              │
+│       │                       │                              │
+│       ▼                       ▼                              │
+│  JSON artifact            JSON artifact                     │
+│  (ls-scraped-data)        (all-scraped-data)                │
+│       │                       │                              │
+└───────┼───────────────────────┼──────────────────────────────┘
+        │                       │
+        ▼                       ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    OCI 서버 (scheduler.py)                   │
+│                                                              │
+│  import_ls (:05, :35)     import_all (:10, :40)             │
+│       │                       │                              │
+│       ▼                       ▼                              │
+│  import_ls_artifact.py    import_all_artifact.py             │
+│       │                       │                              │
+│       └───────┬───────────────┘                              │
+│               ▼                                              │
+│          PostgreSQL                                          │
+│          (INSERT ON CONFLICT dedup)                          │
+│               │                                              │
+│               ▼                                              │
+│  scraper.py (30분 간격)                                     │
+│  ├─ enrich_data() — DBfi gate URL 복구                      │
+│  └─ daily_send_report() — Telegram 전송                    │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 2.2 타이밍 다이어그램
+
+```
+KST 시간    GitHub Actions                서버 scheduler
+────────    ──────────────                ──────────────
+08:00       scrape-ls.yml 실행 시작
+08:02         standalone_ls_scraper 완료
+08:03         artifact upload 완료
+08:05                                     import_ls_artifact 실행
+08:05       scrape-all.yml 실행 시작
+08:07         standalone_all_scraper 완료
+08:08         artifact upload 완료
+08:10                                     import_all_artifact 실행
+08:15                                     scraper.py (enrich+send)
+08:30       scrape-ls.yml 실행 시작
+...                                      ...
+```
+
+**핵심 설계 원칙**:
+- LS와 전체 스크래퍼의 cron을 **5분 staggered**로 배치 (GitHub Actions 동시 실행 부하 방지)
+- 각 import job은 대응되는 scrape cron의 **5분 후**에 실행 (artifact 업로드 완료 대기)
+- import job은 성공한 최신 workflow run의 artifact만 가져오므로, 중복 import되지 않음
+
+---
+
+## 3. 파일별 상세
+
+### 3.1 GitHub Actions Workflows
+
+#### `.github/workflows/scrape-ls.yml` — LS증권 전용
+
+```yaml
+on:
+  schedule:
+    - cron: '0,30 23 * * 0-4'     # KST 월~금 08:00~08:30
+    - cron: '0,30 0-8 * * 1-5'    # KST 화~토 09:00~17:30
+    - cron: '0 9 * * 1-5'         # KST 화~토 18:00
+  workflow_dispatch:
+```
+
+- `standalone_ls_scraper.py` 실행 → JSON artifact (`ls-scraped-data`)
+- LS증권은 `LS_detail()`로 상세 페이지까지 크롤링해야 하므로 별도 workflow 유지
+- **이유**: LS는 msg URL 복구(reconstruct_msg_url_from_db)에 DB 접근이 필요 → 서버에서 import 시 후처리
+
+#### `.github/workflows/scrape-all.yml` — 나머지 24개 증권사
+
+```yaml
+on:
+  schedule:
+    - cron: '5,35 23 * * 0-4'     # KST 월~금 08:05~08:35
+    - cron: '5,35 0-8 * * 1-5'    # KST 화~토 09:05~17:35
+    - cron: '5 9 * * 1-5'         # KST 화~토 18:05
+  workflow_dispatch:
+    inputs:
+      firms:       # 특정 증권사만 (쉼표 구분, 빈칸=전체)
+      timeout:     # 기본 120초
+```
+
+- `standalone_all_scraper.py` 실행 → JSON artifact (`all-scraped-data`)
+- `DB_BACKEND=sqlite`로 DB 접근 없이 실행 (GitHub Actions runner는 PostgreSQL 접근 불가)
+- `SOCKS_PROXY_URL=''` — GitHub Actions 클린 IP이므로 프록시 불필요
+- `retention-days: 1` — artifact 1일 보관 (서버 import가 완료되면 불필요)
+- `overwrite: true` — 동일 이름 artifact 덮어쓰기
+
+### 3.2 Standalone Scrapers
+
+#### `scripts/standalone_all_scraper.py`
+
+**목적**: 기존 `scraper.py`의 `checkNewArticle()` 함수를 그대로 재사용하여 모든 증권사를 GitHub Actions에서 실행.
+
+```python
+IMPORT_MAP = {
+    "LS_0":               ("modules.LS_0",               "LS_checkNewArticle",               False),
+    "ShinHanInvest_1":    ("modules.ShinHanInvest_1",    "ShinHanInvest_checkNewArticle",     True),
+    "NHQV_2":             ("modules.NHQV_2",             "NHQV_checkNewArticle",              True),
+    ...
+    "Yuanta_27":          ("modules.Yuanta_27",          "Yuanta_checkNewArticle",            True),
+}
+```
+
+**실행 흐름**:
+1. `IMPORT_MAP`에서 대상 증권사 결정 (`--firms` 또는 전체, LS는 `SKIP_FIRMS`로 기본 제외)
+2. 각 모듈의 `checkNewArticle` 함수를 `importlib.import_module`로 동적 로딩
+3. **Phase 1: 동기 스크래퍼 (7개)** — 순차 실행 (requests 기반, 블로킹)
+4. **Phase 2: 비동기 스크래퍼 (17개)** — `asyncio.gather(*tasks)` 동시 실행
+5. 결과 JSON을 stdout으로 출력 → GitHub Actions가 artifact로 업로드
+
+**출력 JSON 구조**:
+```json
+{
+  "scraped_at": "2026-05-31T08:05:00",
+  "source": "github-actions",
+  "total_firms": 24,
+  "success_firms": 22,
+  "failed_firms": 2,
+  "total_articles": 7500,
+  "firms": [
+    {
+      "name": "HANA_3",
+      "status": "success",
+      "count": 510,
+      "elapsed_sec": 3.5,
+      "articles": [{ "sec_firm_order": 3, "article_title": "...", ... }]
+    },
+    {
+      "name": "DBfi_19",
+      "status": "error",
+      "error": "Connection timeout",
+      "articles": []
+    }
+  ]
+}
+```
+
+**제외된 증권사**:
+| 키 | 사유 |
+|----|------|
+| `LS_0` | 별도 `scrape-ls.yml`에서 처리 (상세 페이지 크롤링 필요) |
+| `eugenefn_12` | 세션 만료 이슈 (보류) |
+| `Koreainvestment_13` | Selenium 필요 (GitHub Actions에서 Chrome 설치 부담) |
+| `iMfnsec_18` | 보류 |
+
+#### `scripts/standalone_ls_scraper.py`
+
+- LS증권 전용. 목록 2페이지 + 각 게시글 상세 페이지(msg URL 추출)까지 수행
+- 10개 게시판 × 2페이지 × 20건 = 최대 400건
+- WARP 프록시 불필요 (GitHub Actions 클린 IP)
+
+### 3.3 Import Scripts
+
+#### `scripts/import_ls_artifact.py`
+
+```bash
+uv run python scripts/import_ls_artifact.py [--repo ...] [--json-file ...]
+```
+
+1. `gh run list --workflow scrape-ls.yml --status success` → 최신 run ID
+2. `gh run download` → `ls-scraped-data` artifact 다운로드
+3. DB에 이미 존재하는 key는 건너뛰고 신규만 `insert_json_data_list()` (ON CONFLICT dedup)
+4. `telegram_url`이 없는 LS 레포트에 대해 `LS_detail()`로 msg URL 복구 후처리
+
+#### `scripts/import_all_artifact.py`
+
+```bash
+uv run python scripts/import_all_artifact.py [--repo ...] [--dry-run] [--json-file ...]
+```
+
+1. `gh run list --workflow scrape-all.yml --status success` → 최신 run ID
+2. `gh run download` → `all-scraped-data` artifact 다운로드
+3. 증권사별 `db.insert_json_data_list(articles)` (ON CONFLICT dedup)
+4. **후처리**: DBfi 증권사(sec_firm_order=19)의 `telegram_url`이 비어있는 건들에 대해 `DBfi_detail()`로 gate URL 복구
+5. `--dry-run` 플래그로 DB insert 없이 로직 검증 가능
+6. `--json-file`로 GitHub Actions 없이 로컬 JSON 파일 import 가능
+7. `--skip-post-process`로 후처리 생략 가능
+
+### 3.4 서버 운영 파일
+
+#### `scraper.py` (전환 후)
+
+**기본 모드** (`EMERGENCY_SCRAPE` 미설정):
+```
+main()
+  ├─ [스크래핑 건너뜀 — GitHub Actions가 담당]
+  ├─ enrich_data()       # DBfi gate URL 복구
+  └─ daily_send_report() # Telegram 전송
+```
+
+**비상 모드** (`EMERGENCY_SCRAPE=1`):
+```
+main()
+  ├─ _emergency_scrape()  # 서버 직접 크롤링 → DB insert
+  ├─ enrich_data()
+  └─ daily_send_report()
+```
+
+- `_EMERGENCY` 플래그로 import 자체를 조건부 처리 (미사용 모듈 로딩 방지)
+- `enrich_data()`는 `DBfi_detail`만 여전히 import (기본 모드에서 필요)
+- LS, DS 증권사는 enrich_data()에서 `pass` 처리 (각각 GitHub Actions/LS import에서 처리)
+
+#### `scheduler.py` (전환 후)
+
+**등록된 Job**:
+```
+1. main_scraper_job        */30 * * * * (jitter=300)   → scraper.py (enrich+send)
+2. import_ls_artifact_job  5,35 * * * * (jitter=60)    → import_ls_artifact.py
+3. import_all_artifact_job 10,40 * * * * (jitter=60)   → import_all_artifact.py
+```
+
+- `run_import_ls()` / `run_import_all()`: subprocess로 import 스크립트 호출, stdout 요약만 로깅
+- timeout: LS 300초, ALL 600초
+
+### 3.5 Emergency Fallback
+
+#### `scripts/emergency_scrape_all.sh`
+
+```bash
+# 전체 증권사 비상 스크래핑
+bash scripts/emergency_scrape_all.sh
+
+# 특정 증권사만
+EMERGENCY_FIRMS="HANA_3,KBsec_4" bash scripts/emergency_scrape_all.sh
+```
+
+1. `standalone_all_scraper.py` 실행 → JSON 파일로 저장
+2. `import_all_artifact.py --json-file`로 DB import
+
+**또는** `EMERGENCY_SCRAPE=1 uv run scraper.py` 로 scheduler를 통해 기존 방식으로 폴백.
+
+---
+
+## 4. 검증 결과
+
+### 4.1 서버 vs GitHub Actions 비교
+
+2026-05-31 서버 로그와 standalone scraper의 HANA_3 결과를 비교 검증:
+
+| 항목 | 서버 scraper.py | standalone_all_scraper.py |
+|------|-----------------|---------------------------|
+| HANA_3 크롤링 건수 | 510건 | 510건 |
+| 실행 시간 | ~3.5s | ~3.5s |
+| 아티클 필드 구조 | 동일 | 동일 |
+| `checkNewArticle` 함수 | `modules.HANA_3` | `modules.HANA_3` (동일 모듈) |
+
+### 4.2 import dry-run 검증
+
+```bash
+uv run python scripts/import_all_artifact.py \
+  --json-file /tmp/mock_all_artifact.json \
+  --dry-run --skip-post-process
+```
+
+```
+[HANA_3] DRY-RUN: would insert/update 2 articles
+[KBsec_4] DRY-RUN: would insert/update 1 articles
+[BNKfn_23] DRY-RUN: would insert/update 2 articles
+Import complete: 0 inserted, 0 updated, 0 errors
+=== All-Firms Import Complete ===
+```
+
+### 4.3 서버 DB 현황 (2026-05-31)
+
+- 전체 증권사 29개, 총 약 26만건의 레코드
+- 오늘 신규 insert: 2건 (하나증권 1, 미래에셋 1)
+- 나머지 7,423건은 ON CONFLICT UPDATE
+- DBfi(19), BNK(23) 두 증권사는 서버에서도 이미 0건 반환 (소스 사이트 IP 차단)
+
+### 4.4 `gh` CLI 서버 인증 상태
+
+```
+✓ Logged in to github.com account liante0904
+- Token scopes: 'admin:public_key', 'gist', 'read:org', 'repo'
+```
+
+artifact 다운로드에 필요한 `repo` 스코프 보유.
+
+---
+
+## 5. 운영 절차
+
+### 5.1 초기 배포
+
+```bash
+# 1. GitHub PR merge
+git push origin feat/gh-actions-all-scrapers
+# → GitHub에서 PR 생성 → main에 merge
+
+# 2. 서버에 반영
+ssh oci
+cd ~/workspace/external.reports-hub/apps/scrapers/ssh-reports-scraper
+git pull origin main
+
+# 3. scheduler 재시작
+pkill -f "scheduler.py"
+uv run scheduler.py &
+
+# 4. GitHub Actions 수동 실행 테스트
+# GitHub → Actions → "All-Firms Scraper" → Run workflow (firms=HANA_3)
+# → artifact 확인 → 서버에서 import 테스트
+uv run python scripts/import_all_artifact.py --dry-run
+uv run python scripts/import_all_artifact.py
+```
+
+### 5.2 일상 운영
+
+- GitHub Actions가 cron에 따라 자동 실행
+- 서버 `scheduler.py`가 자동으로 artifact import + enrich + send
+- GitHub Actions 로그에서 각 증권사별 상태 확인 가능
+- `SCRAPER_HEALTH_ERRORS` 발생 시 Telegram 알람 (기존 메커니즘 유지)
+
+### 5.3 비상 대응
+
+**상황 1: GitHub Actions 전체 장애**
+```bash
+ssh oci
+cd ~/workspace/external.reports-hub/apps/scrapers/ssh-reports-scraper
+bash scripts/emergency_scrape_all.sh
+```
+
+**상황 2: 특정 증권사만 GitHub Actions에서 실패**
+```bash
+EMERGENCY_FIRMS="DBfi_19,BNKfn_23" bash scripts/emergency_scrape_all.sh
+```
+
+**상황 3: scheduler 자체를 비상 모드로 전환**
+```bash
+EMERGENCY_SCRAPE=1 uv run scheduler.py &
+```
+
+### 5.4 모니터링
+
+- **GitHub Actions 탭**: 각 workflow 실행 이력, 성공/실패, 소요 시간
+- **Artifact**: 가장 최근 성공한 run의 JSON 데이터 (1일 보관)
+- **서버 로그**: `~/logs/YYYYMMDD/YYYYMMDD_scheduler.log`
+- **DB**: `tbl_sec_reports` 테이블의 `save_time` 컬럼으로 최신 import 시간 확인
+
+---
+
+## 6. DB Schema (관련 부분)
+
+### `tbl_sec_reports` — upsert 로직
+
+```sql
+INSERT INTO tbl_sec_reports (
+    sec_firm_order, article_board_order, firm_nm, reg_dt,
+    article_title, article_url, main_ch_send_yn, download_url,
+    telegram_url, pdf_url, writer, mkt_tp, key, save_time
+) VALUES %s
+ON CONFLICT (key) DO UPDATE SET
+    sec_firm_order      = EXCLUDED.sec_firm_order,
+    firm_nm             = EXCLUDED.firm_nm,
+    article_title       = EXCLUDED.article_title,
+    reg_dt              = EXCLUDED.reg_dt,
+    writer              = EXCLUDED.writer,
+    mkt_tp              = EXCLUDED.mkt_tp,
+    download_url        = COALESCE(NULLIF(EXCLUDED.download_url, ''), tbl_sec_reports.download_url),
+    telegram_url        = COALESCE(NULLIF(EXCLUDED.telegram_url, ''), tbl_sec_reports.telegram_url),
+    pdf_url             = COALESCE(NULLIF(EXCLUDED.pdf_url, ''), tbl_sec_reports.pdf_url)
+RETURNING key, (xmax = 0) AS inserted
+```
+
+- **key**: `article_url`을 해시 기반으로 생성한 unique identifier
+- **ON CONFLICT**: 동일 key가 이미 존재하면 update, 없으면 insert
+- **COALESCE**: 새로운 값이 빈 문자열이면 기존 값 유지 (다른 소스에서 채운 telegram_url 보존)
+- **RETURNING**: `xmax = 0`이면 신규 insert, 아니면 update
+
+---
+
+## 7. 알려진 이슈 & 한계
+
+| 이슈 | 상태 | 비고 |
+|------|------|------|
+| DBfi(19) 0건 반환 | 서버/GA 동일 | 소스 사이트 IP 차단 의심, GA에서 살아날 가능성 있음 |
+| BNK(23) 0건 반환 | 서버/GA 동일 | 상동 |
+| 한국투자(13) Selenium 필요 | 보류 | GitHub Actions에 Chrome 설치로 해결 가능 (추후) |
+| 유진투자(12) 세션 만료 | 보류 | 세션 관리 방식 개선 필요 |
+| iMfnsec(18) | 보류 | 미구현 |
+| LS(0) WARP 의존 | GA에서 해결 | GitHub Actions 클린 IP로 WARP 불필요 |
+| `firm_nm: "Unknown(3)"` | GA only | SQLite에 FirmInfo 테이블 없음 → DB import 시 `sec_firm_order`로 복원 |
+| GitHub Actions runner 2-core 제한 | 감수 | 24개 증권사 순차/병렬 실행으로 2~3분 내 완료 |
+
+---
+
+## 8. 향후 개선 가능성
+
+1. **한국투자증권 Selenium**: GitHub Actions에 Chrome 설치 step 추가 → `Koreainvestment_13` 활성화
+2. **Matrix build**: 24개 증권사를 각각 독립 job으로 분할 → 병렬성 극대화 (최대 20 parallel jobs)
+3. **알람 연동**: GitHub Actions 실패 시 Telegram/Discord 웹훅
+4. **Retention 정책**: artifact 보관 기간을 1일 → 3일로 늘려 장애 복구 용이성 확보
+5. **slack/discord notification**: `scrape-all.yml`에 `if: failure()` step 추가

--- a/modules/Koreainvestment_13.py
+++ b/modules/Koreainvestment_13.py
@@ -29,6 +29,9 @@ async def Koreainvestment_selenium_checkNewArticle():
 
     TARGET_URL_0 = config.get_urls("Koreainvestment_13")[0]
     
+    # 백필 등 고페이지 수집용 — KOREAMAX_PAGES 환경변수 (기본 10)
+    _max_pages = int(os.getenv("KOREAMAX_PAGES", "10"))
+
     CATEGORIES = [
         {"name": "전체", "board_order": 0, "script": None, "mkt_tp": "KR"},
         {"name": "미국 현지 리서치", "board_order": 10, "script": "onTab1Selected('stifel', 1);", "mkt_tp": "GLOBAL"}
@@ -94,7 +97,7 @@ async def Koreainvestment_selenium_checkNewArticle():
                 driver.execute_script(cat["script"])
                 time.sleep(2)
 
-            for page in range(1, 11):
+            for page in range(1, _max_pages + 1):
                 if page > 1:
                     driver.execute_script(f"goPage({page});")
                     time.sleep(2)

--- a/modules/Koreainvestment_13.py
+++ b/modules/Koreainvestment_13.py
@@ -41,18 +41,27 @@ async def Koreainvestment_selenium_checkNewArticle():
     chrome_options.add_argument("--disable-gpu")
     chrome_options.add_argument("--remote-allow-origins=*")
     chrome_options.add_argument("--disable-software-rasterizer")
-    
+
+    import platform as _plat
+    _is_arm = _plat.machine() in ("aarch64", "arm64")
+
     # 시스템에 설치된 chromedriver 우선 확인 (ARM64 호환성 해결)
     system_chromedriver = "/usr/bin/chromedriver"
-    system_chrome = "/usr/bin/chromium"
+    system_chrome = "/usr/bin/chromium-browser"
+    snap_chromedriver = "/snap/bin/chromium.chromedriver"
 
     if os.path.exists(system_chromedriver):
         logger.debug(f"KoreaInvestment Scraper: Using system chromedriver at {system_chromedriver}")
         service = Service(executable_path=system_chromedriver)
-        if os.path.exists(system_chrome):
-            chrome_options.binary_location = system_chrome
+    elif os.path.exists(snap_chromedriver):
+        logger.debug(f"KoreaInvestment Scraper: Using snap chromedriver at {snap_chromedriver}")
+        service = Service(executable_path=snap_chromedriver)
+    elif _is_arm:
+        # ARM64에서는 webdriver_manager 대신 시스템 패키지 필수
+        logger.warning("KoreaInvestment: ARM64 detected, trying default Service()")
+        service = Service()
     else:
-        # 도커 외부(로컬) 환경용
+        # x86_64 환경 (GitHub Actions 등) — webdriver_manager 사용
         try:
             logger.debug("KoreaInvestment Scraper: System chromedriver not found, trying ChromeDriverManager...")
             service = Service(ChromeDriverManager().install())
@@ -60,7 +69,10 @@ async def Koreainvestment_selenium_checkNewArticle():
             logger.error(f"Failed to install ChromeDriver: {e}")
             service = Service()
 
-    binary_paths = ["/usr/bin/chromium-browser", "/usr/bin/chromium", "/usr/bin/google-chrome"]
+    binary_paths = [
+        "/usr/bin/chromium-browser", "/usr/bin/chromium", "/usr/bin/google-chrome",
+        "/snap/bin/chromium",
+    ]
     for bp in binary_paths:
         if os.path.exists(bp):
             chrome_options.binary_location = bp

--- a/modules/TOSSinvest_15.py
+++ b/modules/TOSSinvest_15.py
@@ -1,5 +1,5 @@
-from loguru import logger
 # -*- coding:utf-8 -*- 
+from loguru import logger
 import gc
 import requests
 import re
@@ -15,51 +15,86 @@ from models.ConfigManager import config
 
 def TOSSinvest_checkNewArticle():
     sec_firm_order      = 15
-    article_board_order = 0
     json_data_list = []
 
     requests.packages.urllib3.disable_warnings()
  
     TARGET_URL_TUPLE = config.get_urls("TOSSinvest_15")
     
-    for article_board_order, TARGET_URL in enumerate(TARGET_URL_TUPLE):
+    for article_board_order, BASE_URL in enumerate(TARGET_URL_TUPLE):
         firm_info = FirmInfo(
             sec_firm_order=sec_firm_order,
             article_board_order=article_board_order
         )
 
-        scraper = SyncWebScraper(TARGET_URL, firm_info)
-        
-        # HTML parse
-        jres = scraper.GetJson()
-        
-        # HTML parse
-        soupList = jres['result']['list']
-        
-        # logger.debug('*' *40)
-        # logger.debug(soupList)
-        
-        # logger.debug('*' *40)
-        
-        nNewArticleCnt = 0
-        for list in soupList:
-            LIST_ARTICLE_TITLE = list['title']
-            LIST_ARTICLE_URL   =  list['files'][0]['filePath']
-            reg_dt = list['createdAt'].split("T")[0]
-            json_data_list.append({
-                "sec_firm_order":sec_firm_order,
-                "article_board_order":article_board_order,
-                "firm_nm":firm_info.get_firm_name(),
-                "reg_dt": re.sub(r"[-./]", "", reg_dt),
-                "download_url": LIST_ARTICLE_URL,
-                "telegram_url": LIST_ARTICLE_URL,
-                "article_title":LIST_ARTICLE_TITLE,
-                "key":LIST_ARTICLE_URL,
-                "save_time": datetime.now().isoformat()
-            })
-            
+        # ── 페이징 처리: page=0부터 totalPageCount까지 순회 ──
+        page = 0
+        total_pages = None
+        while True:
+            paged_url = re.sub(r'page=\d+', f'page={page}', BASE_URL)
+            if 'page=' not in paged_url:
+                paged_url += ('&' if '?' in paged_url else '?') + f'page={page}'
+
+            scraper = SyncWebScraper(paged_url, firm_info)
+            try:
+                jres = scraper.GetJson()
+            except Exception as e:
+                logger.error(f"TOSS page {page} fetch failed: {e}")
+                break
+
+            soupList = jres.get('result', {}).get('list', [])
+            if not soupList:
+                break
+
+            # 첫 페이지만 totalPageCount 확인
+            if total_pages is None:
+                paging = jres.get('result', {}).get('pagingParam', {})
+                total_pages = paging.get('totalPageCount', 1)
+                logger.info(f"TOSS Scraper [{firm_info.get_firm_name()}] board={article_board_order}: "
+                           f"totalPages={total_pages}, size={len(soupList)}")
+
+            for item in soupList:
+                title = item.get('title', '')
+                download_url = ''
+                if item.get('files'):
+                    download_url = item['files'][0].get('filePath', '')
+                if not download_url:
+                    download_url = item.get('contentImage', '')
+
+                reg_dt = item.get('createdAt', '').split("T")[0]
+
+                # writer: author 필드 우선, 없으면 contents에서 추출
+                writer = item.get('author', '')
+                if not writer:
+                    contents = item.get('contents', '')
+                    m = re.search(r'작성자[:\s]*([^<\n]+)', contents)
+                    if m:
+                        writer = m.group(1).strip()
+
+                # mkt_tp: English 카테고리면 GLOBAL
+                cat_name = item.get('category', {}).get('categoryName', '')
+                mkt_tp = "GLOBAL" if 'english' in cat_name.lower() else "KR"
+
+                json_data_list.append({
+                    "sec_firm_order": sec_firm_order,
+                    "article_board_order": article_board_order,
+                    "firm_nm": firm_info.get_firm_name(),
+                    "reg_dt": re.sub(r"[-./]", "", reg_dt),
+                    "download_url": download_url,
+                    "telegram_url": download_url,
+                    "article_title": title,
+                    "writer": writer,
+                    "mkt_tp": mkt_tp,
+                    "key": download_url,
+                    "save_time": datetime.now().isoformat()
+                })
+
+            page += 1
+            if total_pages and page >= total_pages:
+                break
+
     # 메모리 정리
-    del jres, soupList
     gc.collect()
 
+    logger.info(f"TOSS Scraper: total {len(json_data_list)} articles collected")
     return json_data_list

--- a/scheduler.py
+++ b/scheduler.py
@@ -13,10 +13,9 @@ from utils.logger_util import setup_logger
 setup_logger("scheduler")
 
 def run_scraper():
-    """메인 스크래퍼 실행 (scraper.py)"""
-    logger.info("--- [Job Start] Main Scraper (scraper.py) ---")
+    """메인 스크래퍼 실행 (scraper.py) — enrich + send (스크래핑은 GitHub Actions로 전환)"""
+    logger.info("--- [Job Start] Main Scraper (enrich + send) ---")
     try:
-        # uv run scraper.py 실행 (출력 캡처)
         result = subprocess.run(
             ["uv", "run", "scraper.py"],
             capture_output=True,
@@ -32,6 +31,59 @@ def run_scraper():
     except Exception as e:
         logger.error(f"Execution Error: {e}")
     logger.info("--- [Job End] Main Scraper ---")
+
+
+def run_import_ls():
+    """LS 증권사 GitHub Actions 아티팩트 → DB import"""
+    logger.info("--- [Job Start] LS Artifact Import ---")
+    try:
+        result = subprocess.run(
+            ["uv", "run", "python", "scripts/import_ls_artifact.py"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=300,
+        )
+        if result.returncode != 0:
+            logger.error(f"LS import exited with code {result.returncode}")
+            if result.stderr:
+                logger.error(f"LS import stderr:\n{result.stderr[:500]}")
+        else:
+            # 요약만 출력
+            for line in result.stdout.strip().split('\n'):
+                if any(kw in line for kw in ('Import', 'skipped', 'inserted', 'Complete')):
+                    logger.info(f"[LS-import] {line.strip()}")
+    except subprocess.TimeoutExpired:
+        logger.error("LS import timed out (300s)")
+    except Exception as e:
+        logger.error(f"LS import error: {e}")
+    logger.info("--- [Job End] LS Artifact Import ---")
+
+
+def run_import_all():
+    """전체 증권사 GitHub Actions 아티팩트 → DB import"""
+    logger.info("--- [Job Start] All-Firms Artifact Import ---")
+    try:
+        result = subprocess.run(
+            ["uv", "run", "python", "scripts/import_all_artifact.py"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=600,
+        )
+        if result.returncode != 0:
+            logger.error(f"All-firms import exited with code {result.returncode}")
+            if result.stderr:
+                logger.error(f"All-firms import stderr:\n{result.stderr[:500]}")
+        else:
+            for line in result.stdout.strip().split('\n'):
+                if any(kw in line for kw in ('Import', 'inserted', 'updated', 'Complete', 'SUCCESS')):
+                    logger.info(f"[All-import] {line.strip()}")
+    except subprocess.TimeoutExpired:
+        logger.error("All-firms import timed out (600s)")
+    except Exception as e:
+        logger.error(f"All-firms import error: {e}")
+    logger.info("--- [Job End] All-Firms Artifact Import ---")
 
 # 최적화 실패로 인한 일시 주석 처리
 # def run_enricher_batch(limit=200):
@@ -92,14 +144,30 @@ def run_ai_summary(limit):
 
 scheduler = BlockingScheduler()
 
-# [스케줄 1] 메인 스크래퍼: */30 0,5-12,14-23 * * * (기존 crontab 복제)
+# [스케줄 1] 메인 스크래퍼 (enrich + send): 30분 간격
 scheduler.add_job(
     run_scraper,
-    CronTrigger(minute='*/30', hour='0,5-12,14-23', jitter=300), # 300초(5분) 랜덤 지터 추가
+    CronTrigger(minute='*/30', hour='0,5-12,14-23', jitter=300),
     id="main_scraper_job"
 )
 
-# [스케줄 2] Enricher 배치: 15분마다 2000건 인프로세스 (~28만건/35시간) -> 최적화 실패로 인한 일시 비활성화
+# [스케줄 2] LS 아티팩트 import: GitHub Actions 완료 시점에 맞춰 매시 05, 35분
+#   LS cron: 0,30 → GitHub Actions가 :00, :30에 실행 → import는 :05, :35
+scheduler.add_job(
+    run_import_ls,
+    CronTrigger(minute='5,35', hour='0,5-12,14-23', jitter=60),
+    id="import_ls_artifact_job"
+)
+
+# [스케줄 3] 전체 증권사 아티팩트 import: GitHub Actions 완료 시점에 맞춰 매시 10, 40분
+#   scrape-all cron: 5,35 → GitHub Actions가 :05, :35에 실행 → import는 :10, :40
+scheduler.add_job(
+    run_import_all,
+    CronTrigger(minute='10,40', hour='0,5-12,14-23', jitter=60),
+    id="import_all_artifact_job"
+)
+
+# [스케줄 4] Enricher 배치: 15분마다 2000건 인프로세스 (~28만건/35시간) -> 최적화 실패로 인한 일시 비활성화
 # scheduler.add_job(
 #     run_enricher_batch,
 #     CronTrigger(minute='*/15', jitter=60),

--- a/scraper.py
+++ b/scraper.py
@@ -17,35 +17,38 @@ from utils.telegram_util import sendMarkDownText
 from utils.sqlite_util import convert_sql_to_telegram_messages
 from models.db_factory import get_db
 
-# business modules
-from modules.LS_0 import LS_checkNewArticle, LS_detail
-from modules.ShinHanInvest_1 import ShinHanInvest_checkNewArticle
-from modules.NHQV_2 import NHQV_checkNewArticle
-from modules.HANA_3 import HANA_checkNewArticle
-from modules.KBsec_4 import KB_checkNewArticle
-from modules.Samsung_5 import Samsung_checkNewArticle
-from modules.Sangsanginib_6 import Sangsanginib_checkNewArticle
-from modules.Shinyoung_7 import Shinyoung_checkNewArticle
-from modules.Miraeasset_8 import Miraeasset_checkNewArticle
-from modules.Hmsec_9 import Hmsec_checkNewArticle
-from modules.Kiwoom_10 import Kiwoom_checkNewArticle
-from modules.DS_11 import DS_checkNewArticle
-from modules.eugenefn_12 import eugene_checkNewArticle
-from modules.Koreainvestment_13 import Koreainvestment_selenium_checkNewArticle
-from modules.DAOL_14 import DAOL_checkNewArticle
-from modules.TOSSinvest_15 import TOSSinvest_checkNewArticle
-from modules.Leading_16 import Leading_checkNewArticle
-from modules.Daeshin_17 import Daeshin_checkNewArticle
-from modules.iMfnsec_18 import iMfnsec_checkNewArticle
-from modules.DBfi_19 import DBfi_checkNewArticle, DBfi_detail
-from modules.MERITZ_20 import MERITZ_checkNewArticle
-from modules.Hanwhawm_21 import Hanwha_checkNewArticle
-from modules.Hygood_22 import Hanyang_checkNewArticle
-from modules.BNKfn_23 import BNK_checkNewArticle
-from modules.Kyobo_24 import Kyobo_checkNewArticle
-from modules.IBKs_25 import IBK_checkNewArticle
-from modules.SKS_26 import Sks_checkNewArticle
-from modules.Yuanta_27 import Yuanta_checkNewArticle # 비동기 버전 (파일명 변경됨)
+# business modules — GitHub Actions standalone 스크래퍼로 모두 분리됨
+# 비상시 EMERGENCY_SCRAPE=1 환경변수로 서버 직접 스크래핑 활성화 가능
+_EMERGENCY = os.getenv("EMERGENCY_SCRAPE", "0") == "1"
+
+if _EMERGENCY:
+    from modules.ShinHanInvest_1 import ShinHanInvest_checkNewArticle
+    from modules.NHQV_2 import NHQV_checkNewArticle
+    from modules.HANA_3 import HANA_checkNewArticle
+    from modules.KBsec_4 import KB_checkNewArticle
+    from modules.Samsung_5 import Samsung_checkNewArticle
+    from modules.Sangsanginib_6 import Sangsanginib_checkNewArticle
+    from modules.Shinyoung_7 import Shinyoung_checkNewArticle
+    from modules.Miraeasset_8 import Miraeasset_checkNewArticle
+    from modules.Hmsec_9 import Hmsec_checkNewArticle
+    from modules.Kiwoom_10 import Kiwoom_checkNewArticle
+    from modules.DS_11 import DS_checkNewArticle
+    from modules.DAOL_14 import DAOL_checkNewArticle
+    from modules.TOSSinvest_15 import TOSSinvest_checkNewArticle
+    from modules.Leading_16 import Leading_checkNewArticle
+    from modules.Daeshin_17 import Daeshin_checkNewArticle
+    from modules.DBfi_19 import DBfi_checkNewArticle, DBfi_detail
+    from modules.MERITZ_20 import MERITZ_checkNewArticle
+    from modules.Hanwhawm_21 import Hanwha_checkNewArticle
+    from modules.Hygood_22 import Hanyang_checkNewArticle
+    from modules.BNKfn_23 import BNK_checkNewArticle
+    from modules.Kyobo_24 import Kyobo_checkNewArticle
+    from modules.IBKs_25 import IBK_checkNewArticle
+    from modules.SKS_26 import Sks_checkNewArticle
+    from modules.Yuanta_27 import Yuanta_checkNewArticle
+else:
+    # enrich_data()에서 DBfi_detail만 여전히 필요함
+    from modules.DBfi_19 import DBfi_detail
 
 load_dotenv()
 token = os.getenv('TELEGRAM_BOT_TOKEN_REPORT_ALARM_SECRET')
@@ -111,6 +114,7 @@ def log_scraper_health(name, rows):
         SCRAPER_HEALTH_ERRORS.append(msg)
         logger.error(msg)
 
+
 async def enrich_data():
     logger.info("Starting data enrichment process...")
     db = get_db()
@@ -157,49 +161,8 @@ async def enrich_data():
                             fixed = await DBfi_detail(articles=backlog, firm_info=firm_info, db=db)
                             fixed_count = sum(1 for r in fixed if r.get('telegram_url', '').startswith('https://whub.dbsec.co.kr/pv/gate'))
                             logger.success(f"[DBfi][유휴] {fixed_count}/{len(backlog)}건 gate URL 복구 완료")
-                elif sec_firm_order == 0:  # LS
-                    update_records = await LS_detail(articles=records, firm_info=firm_info)
-                    tasks = [db.update_telegram_url(r['report_id'], r['telegram_url'], r.get('article_title'), pdf_url=r.get('pdf_url') or r['telegram_url']) for r in update_records if r.get('telegram_url')]
-                    if tasks: await asyncio.gather(*tasks)
-
-                    # 최근 1일 이내 upload/ fallback → writer 기반 재시도 (reconstruct_msg_url_from_db 개선)
-                    fallback_records = db._fetchall('''
-                        SELECT report_id, article_title, writer, telegram_url, article_url, reg_dt, key
-                        FROM tbl_sec_reports
-                        WHERE sec_firm_order = 0
-                          AND telegram_url LIKE 'https://www.ls-sec.co.kr/upload/%%'
-                          AND save_time::timestamp >= NOW() - INTERVAL '1 day'
-                          AND key IS NOT NULL AND key != ''
-                        ORDER BY save_time DESC
-                        LIMIT 50
-                    ''')
-                    if fallback_records:
-                        logger.info(f"[LS] 최근 upload/ fallback {len(fallback_records)}건 재시도...")
-                        refixed = await LS_detail(articles=fallback_records, firm_info=firm_info)
-                        refix_tasks = [db.update_telegram_url(r['report_id'], r['telegram_url'], r.get('article_title'), pdf_url=r.get('pdf_url') or r['telegram_url']) for r in refixed if r.get('telegram_url', '').startswith('https://msg.ls-sec.co.kr/')]
-                        if refix_tasks:
-                            await asyncio.gather(*refix_tasks)
-                            logger.success(f"[LS] upload/ fallback {len(refix_tasks)}건 msg URL 재복구 완료")
-
-                    # 유휴시간(20시~06시)에는 전체 LS backlog 정리
-                    if is_idle_time:
-                        backlog = db._fetchall('''
-                            SELECT report_id, article_title, writer, telegram_url, article_url, reg_dt, key
-                            FROM tbl_sec_reports
-                            WHERE sec_firm_order = 0
-                              AND (telegram_url IS NULL OR telegram_url = ''
-                                   OR telegram_url NOT LIKE 'https://msg.ls-sec.co.kr/%%')
-                              AND key IS NOT NULL AND key != ''
-                            ORDER BY save_time DESC
-                            LIMIT 200
-                        ''')
-                        if backlog:
-                            logger.info(f"[LS][유휴] 전체 backlog {len(backlog)}건 재처리...")
-                            fixed = await LS_detail(articles=backlog, firm_info=firm_info)
-                            fix_tasks = [db.update_telegram_url(r['report_id'], r['telegram_url'], r.get('article_title'), pdf_url=r.get('pdf_url') or r['telegram_url']) for r in fixed if r.get('telegram_url', '').startswith('https://msg.ls-sec.co.kr/')]
-                            if fix_tasks:
-                                await asyncio.gather(*fix_tasks)
-                                logger.success(f"[LS][유휴] {len(fix_tasks)}건 msg URL 복구 완료")
+                elif sec_firm_order == 0:  # LS → GitHub Actions standalone으로 분리됨
+                    pass
                 elif sec_firm_order == 11:  # DS
                     pass
                 logger.success(f"[{firm_name}] Enrichment completed.")
@@ -226,6 +189,9 @@ async def daily_send_report(date_str=None):
             await db.daily_update_data(date_str=date_str, fetched_rows=rows, type='send')
             logger.success("Daily report sent and DB updated.")
 
+
+# ── Emergency scrape helpers (EMERGENCY_SCRAPE=1 전용) ──
+
 def run_sync_scrapers(sync_funcs, total_data):
     for func in sync_funcs:
         try:
@@ -240,33 +206,27 @@ def run_sync_scrapers(sync_funcs, total_data):
             SCRAPER_HEALTH_ERRORS.append(msg)
             logger.error(msg)
 
+
 async def run_async_scrapers(async_funcs, total_data):
     logger.info(f"Launching {len(async_funcs)} async scrapers...")
     tasks = []
     task_names = []
-    
+
     for f in async_funcs:
         try:
             if not callable(f):
                 continue
-            
-            # 함수를 일단 호출해봅니다.
             res = f()
-            
-            # 호출 결과가 코루틴(awaitable)인 경우에만 tasks에 추가
             if asyncio.iscoroutine(res):
                 tasks.append(res)
                 task_names.append(f.__name__)
-            # 호출 결과가 이미 리스트인 경우 (동기 함수처럼 동작한 경우) 즉시 처리
             elif isinstance(res, list):
                 total_data.extend(res)
                 log_scraper_health(f.__name__, res)
-            # 그 외의 경우 (None 등)
             elif res is not None:
                 msg = f"{f.__name__} returned unexpected type: {type(res)}"
                 SCRAPER_HEALTH_ERRORS.append(msg)
                 logger.error(msg)
-                
         except Exception as e:
             msg = f"Error calling scraper {f.__name__}: {e}"
             SCRAPER_HEALTH_ERRORS.append(msg)
@@ -291,75 +251,62 @@ async def run_async_scrapers(async_funcs, total_data):
             SCRAPER_HEALTH_ERRORS.append(msg)
             logger.error(msg)
 
-async def main(date_str=None):
-    logger.info("=================== SCRAPER START ===================")
+
+async def _emergency_scrape(db):
+    """비상시 서버 직접 스크래핑 (EMERGENCY_SCRAPE=1)."""
+    logger.warning("=== EMERGENCY MODE: 서버 직접 스크래핑 활성화 ===")
     total_data = []
-    db = get_db()
-    
-    # ── LS증권: 목록 2p 스크래핑 → DB 키 비교 → 신규만 detail ──
-    ls_articles = LS_checkNewArticle()
-    if ls_articles:
-        logger.info(f"[LS] 신규 {len(ls_articles)}건 detail 추출 시작")
-        enriched = await LS_detail(ls_articles, db=db)
-        for a in enriched:
-            if a.get("telegram_url"):
-                total_data.append(a)
-        logger.success(f"[LS] {len(enriched)}건 detail 완료")
 
     sync_funcs = [
-        Miraeasset_checkNewArticle, Sks_checkNewArticle, 
+        Miraeasset_checkNewArticle, Sks_checkNewArticle,
         Samsung_checkNewArticle, Shinyoung_checkNewArticle, Hmsec_checkNewArticle,
         TOSSinvest_checkNewArticle, DS_checkNewArticle
     ]
     async_functions = [
         ShinHanInvest_checkNewArticle, Leading_checkNewArticle,
         NHQV_checkNewArticle, HANA_checkNewArticle, KB_checkNewArticle,
-        Sangsanginib_checkNewArticle, Kiwoom_checkNewArticle, 
-        # Koreainvestment_selenium_checkNewArticle, # Selenium 에러 해결 중 (보류)
-        DAOL_checkNewArticle, 
-        Daeshin_checkNewArticle, 
-        # iMfnsec_checkNewArticle, # 보류
+        Sangsanginib_checkNewArticle, Kiwoom_checkNewArticle,
+        DAOL_checkNewArticle, Daeshin_checkNewArticle,
         DBfi_checkNewArticle,
         MERITZ_checkNewArticle, Hanwha_checkNewArticle, Hanyang_checkNewArticle,
         BNK_checkNewArticle, Kyobo_checkNewArticle, IBK_checkNewArticle,
-        # eugene_checkNewArticle # 세션 만료 및 제한 에러 (보류)
-        Yuanta_checkNewArticle # 비동기 버전 (명칭 표준화됨)
+        Yuanta_checkNewArticle
     ]
 
     run_sync_scrapers(sync_funcs, total_data)
     await run_async_scrapers(async_functions, total_data)
 
     if total_data:
-        unique = { d.get("key"): d for d in total_data if d.get("key") }
+        unique = {d.get("key"): d for d in total_data if d.get("key")}
         total_list = list(unique.values())
         try:
             ins, upd = db.insert_json_data_list(total_list)
-            logger.success(f"DB Sync: {ins} new, {upd} updated.")
-            
-            # 새로 insert된 레포트 자동 태그 추출 (enricher) -> 최적화 실패로 인한 일시 주석 처리
-            # new_keys = getattr(db, '_last_inserted_keys', [])
-            # if new_keys:
-            #     try:
-            #         from enricher import EnricherManager
-            #         enricher = EnricherManager(db_manager=db)
-            #         enrich_result = enricher.enrich_by_keys(new_keys)
-            #         logger.info(f"[Enricher] {enrich_result['enriched']}/{len(new_keys)} enriched")
-            #     except Exception as e:
-            #         logger.warning(f"[Enricher] skipped (non-critical): {e}")
-            
-            # DB 삽입 후 잠시 대기하여 트리거/커밋이 확실히 반영되도록 함
+            logger.success(f"[EMERGENCY] DB Sync: {ins} new, {upd} updated.")
             await asyncio.sleep(1)
         except Exception as e:
-            logger.error(f"DB error: {e}")
+            logger.error(f"[EMERGENCY] DB error: {e}")
+    else:
+        logger.warning("[EMERGENCY] No data scraped.")
+
+
+async def main(date_str=None):
+    logger.info("=================== SCRAPER START ===================")
+    db = get_db()
+
+    # ── GitHub Actions 전환 완료: 기본 모드는 enrich + send 만 수행 ──
+    # ── EMERGENCY_SCRAPE=1 시 서버 직접 스크래핑으로 폴백 ──
+    if _EMERGENCY:
+        await _emergency_scrape(db)
 
     await enrich_data()
-    
+
     # 발송 전에 DB 연결을 새로 하거나 세션을 확실히 분리하여 최신 데이터를 가져옴
     await daily_send_report(date_str=date_str)
     logger.info("=================== SCRAPER END =====================")
     if SCRAPER_HEALTH_ERRORS:
         joined = "; ".join(SCRAPER_HEALTH_ERRORS)
         raise RuntimeError(f"Scraper health check failed: {joined}")
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/scraper.py
+++ b/scraper.py
@@ -22,6 +22,7 @@ from models.db_factory import get_db
 _EMERGENCY = os.getenv("EMERGENCY_SCRAPE", "0") == "1"
 
 if _EMERGENCY:
+    from modules.Koreainvestment_13 import Koreainvestment_selenium_checkNewArticle
     from modules.ShinHanInvest_1 import ShinHanInvest_checkNewArticle
     from modules.NHQV_2 import NHQV_checkNewArticle
     from modules.HANA_3 import HANA_checkNewArticle
@@ -263,6 +264,7 @@ async def _emergency_scrape(db):
         TOSSinvest_checkNewArticle, DS_checkNewArticle
     ]
     async_functions = [
+        Koreainvestment_selenium_checkNewArticle,
         ShinHanInvest_checkNewArticle, Leading_checkNewArticle,
         NHQV_checkNewArticle, HANA_checkNewArticle, KB_checkNewArticle,
         Sangsanginib_checkNewArticle, Kiwoom_checkNewArticle,

--- a/scripts/check_firm_health.py
+++ b/scripts/check_firm_health.py
@@ -1,0 +1,20 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from dotenv import load_dotenv; load_dotenv()
+from models.db_factory import get_db
+
+db = get_db()
+conn = db.get_connection()
+cur = conn.cursor()
+cur.execute("""
+    SELECT sec_firm_order, firm_nm, COUNT(*) as total,
+           MAX(reg_dt) as last_reg_dt, MAX(save_time::date) as last_save
+    FROM tbl_sec_reports WHERE sec_firm_order IS NOT NULL
+    GROUP BY sec_firm_order, firm_nm ORDER BY sec_firm_order
+""")
+print(f"{'ord':>3} {'firm':<22} {'total':>7} {'last_reg_dt':>12} {'last_save':>12} status")
+for r in cur.fetchall():
+    last = str(r[2] or "-")
+    stale = "STALE!" if last < "20260501" else ("old" if last < "20260524" else "OK  ")
+    print(f"{r[0]:>3} {str(r[1] or '?'):<22} {r[3]:>7} {last:>12} {str(r[4] or '-'):>12} {stale}")
+conn.close()

--- a/scripts/check_firm_health.py
+++ b/scripts/check_firm_health.py
@@ -1,4 +1,8 @@
+#!/usr/bin/env python3
+"""증권사별 마지막 레포트 일자 건강검진 — 각 증권사의 최신 데이터 확인."""
 import sys, os
+from datetime import date
+
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from dotenv import load_dotenv; load_dotenv()
 from models.db_factory import get_db
@@ -12,9 +16,45 @@ cur.execute("""
     FROM tbl_sec_reports WHERE sec_firm_order IS NOT NULL
     GROUP BY sec_firm_order, firm_nm ORDER BY sec_firm_order
 """)
-print(f"{'ord':>3} {'firm':<22} {'total':>7} {'last_reg_dt':>12} {'last_save':>12} status")
+
+today = date.today()
+URGENT_DAYS = 30
+WARN_DAYS = 7
+
+print(f"{'ord':>3} {'firm':<22} {'total':>7} {'last_reg_dt':>12} {'last_save':>12} {'days_ago':>9} status")
+print("-" * 85)
+
+alerts = []
 for r in cur.fetchall():
-    last = str(r[2] or "-")
-    stale = "STALE!" if last < "20260501" else ("old" if last < "20260524" else "OK  ")
-    print(f"{r[0]:>3} {str(r[1] or '?'):<22} {r[3]:>7} {last:>12} {str(r[4] or '-'):>12} {stale}")
+    o, nm, total, reg_dt, save_dt = r
+    reg_str = str(reg_dt or "-")
+    save_str = str(save_dt or "-")
+
+    try:
+        last_date = date(int(reg_str[:4]), int(reg_str[4:6]), int(reg_str[6:8]))
+        days_ago = (today - last_date).days
+    except:
+        days_ago = -1
+
+    if days_ago >= URGENT_DAYS:
+        status = "STALE"
+        alerts.append((o, nm, days_ago, "URGENT"))
+    elif days_ago >= WARN_DAYS:
+        status = "WARN"
+        alerts.append((o, nm, days_ago, "WARN"))
+    elif days_ago < 0:
+        status = "??"
+    else:
+        status = "OK"
+
+    print(f"{o:>3} {str(nm or '?'):<22} {total:>7} {reg_str:>12} {save_str:>12} {days_ago:>8}d {status}")
+
 conn.close()
+
+if alerts:
+    print("\nALERTS:")
+    for o, nm, days, level in sorted(alerts, key=lambda x: -x[2]):
+        tag = "STALE" if level == "URGENT" else "WARN"
+        print(f"  [{tag}] [{o}] {nm}: {days}d stale")
+else:
+    print("\nAll firms OK")

--- a/scripts/emergency_scrape_all.sh
+++ b/scripts/emergency_scrape_all.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# ============================================================
+# Emergency Scrape All — GitHub Actions 장애시 서버 직접 스크래핑
+# ============================================================
+# 사용법:
+#   bash scripts/emergency_scrape_all.sh
+#
+# 또는 개별 증권사만:
+#   EMERGENCY_FIRMS="HANA_3,KBsec_4" bash scripts/emergency_scrape_all.sh
+# ============================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_DIR"
+
+FIRMS="${EMERGENCY_FIRMS:-}"
+
+echo "============================================"
+echo " EMERGENCY SCRAPE — 서버 직접 스크래핑"
+echo " $(date '+%Y-%m-%d %H:%M:%S')"
+echo "============================================"
+
+# 1. Standalone 스크래퍼 실행 → JSON 저장
+TMPFILE=$(mktemp /tmp/emergency_scrape_XXXXXX.json)
+trap "rm -f $TMPFILE" EXIT
+
+FIRMS_ARG=""
+if [ -n "$FIRMS" ]; then
+    FIRMS_ARG="--firms $FIRMS"
+    echo "[1/2] 특정 증권사 스크래핑: $FIRMS"
+else
+    echo "[1/2] 전체 증권사 스크래핑 (LS 제외)"
+fi
+
+uv run python scripts/standalone_all_scraper.py $FIRMS_ARG --timeout 120 > "$TMPFILE" 2>/tmp/emergency_scrape.log
+
+COUNT=$(python3 -c "import json; d=json.load(open('$TMPFILE')); print(d.get('total_articles', 0))")
+echo "      → $COUNT articles scraped"
+echo ""
+
+# 2. DB import
+echo "[2/2] DB import..."
+uv run python scripts/import_all_artifact.py --json-file "$TMPFILE"
+
+echo ""
+echo "============================================"
+echo " EMERGENCY SCRAPE COMPLETE"
+echo "============================================"

--- a/scripts/import_all_artifact.py
+++ b/scripts/import_all_artifact.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""
+전체 증권사 아티팩트 Import 스크립트
+=====================================
+GitHub Actions에서 생성된 all-scraped-data artifact를 다운로드하여 DB에 import.
+
+1. gh CLI로 최신 artifact 다운로드
+2. JSON 파싱
+3. 증권사별 DB insert (ON CONFLICT key → 자동 dedup)
+4. DBfi gate URL 복구 후처리
+5. unresolved URL 건들 enrich_data() 후처리
+
+사용법:
+  python3 scripts/import_all_artifact.py [--repo liante0904/ssh-reports-scraper] [--dry-run]
+
+환경변수:
+  GITHUB_REPOSITORY: artifact를 가져올 리포지토리
+  ALL_ARTIFACT_NAME: artifact 이름 (기본: all-scraped-data)
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from datetime import datetime
+from loguru import logger
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.logger_util import setup_logger
+setup_logger("import_all")
+
+from models.db_factory import get_db
+from models.FirmInfo import FirmInfo
+
+
+def download_artifact(repo: str, artifact_name: str = "all-scraped-data") -> dict | None:
+    """gh CLI로 최신 workflow run의 artifact 다운로드 → JSON 반환"""
+    tmpdir = tempfile.mkdtemp(prefix="all_artifact_")
+
+    try:
+        result = subprocess.run(
+            [
+                "gh", "run", "list",
+                "--repo", repo,
+                "--workflow", "scrape-all.yml",
+                "--status", "success",
+                "--limit", "1",
+                "--json", "databaseId",
+            ],
+            capture_output=True, text=True, check=True,
+        )
+        runs = json.loads(result.stdout)
+        if not runs:
+            logger.warning("No successful all-firms scraper runs found")
+            return None
+
+        run_id = runs[0]["databaseId"]
+        logger.info(f"Found run ID: {run_id}")
+
+        subprocess.run(
+            [
+                "gh", "run", "download",
+                "--repo", repo,
+                str(run_id),
+                "--name", artifact_name,
+                "--dir", tmpdir,
+            ],
+            capture_output=True, text=True, check=True,
+        )
+
+        json_files = [f for f in os.listdir(tmpdir) if f.endswith(".json")]
+        if not json_files:
+            logger.error("No JSON file in artifact")
+            return None
+
+        json_path = os.path.join(tmpdir, json_files[0])
+        with open(json_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        logger.info(
+            f"Artifact loaded: {data['total_articles']} articles from "
+            f"{data['success_firms']}/{data['total_firms']} firms"
+        )
+        return data
+
+    except subprocess.CalledProcessError as e:
+        logger.error(f"gh CLI error: {e.stderr}")
+        return None
+    except Exception as e:
+        logger.error(f"Download failed: {e}")
+        return None
+
+
+def import_all_firms(data: dict, dry_run: bool = False) -> dict:
+    """전체 증권사 아티팩트 데이터를 DB에 import"""
+    firms = data.get("firms", [])
+    if not firms:
+        logger.info("No firm data to import")
+        return {"inserted": 0, "updated": 0, "errors": 0}
+
+    db = get_db()
+    total_ins = 0
+    total_upd = 0
+    total_err = 0
+
+    for firm in firms:
+        name = firm["name"]
+        articles = firm.get("articles", [])
+
+        if not articles:
+            continue
+
+        if dry_run:
+            logger.info(f"[{name}] DRY-RUN: would insert/update {len(articles)} articles")
+            continue
+
+        try:
+            ins, upd = db.insert_json_data_list(articles)
+            total_ins += ins
+            total_upd += upd
+            status = "NEW" if ins > 0 else "UPD" if upd > 0 else "SKIP"
+            logger.info(f"[{name}] {status}: {ins} inserted, {upd} updated")
+        except Exception as e:
+            total_err += 1
+            logger.error(f"[{name}] DB insert failed: {e}")
+
+    logger.success(
+        f"Import complete: {total_ins} inserted, {total_upd} updated, "
+        f"{total_err} errors"
+    )
+    return {"inserted": total_ins, "updated": total_upd, "errors": total_err}
+
+
+async def post_process_all():
+    """DBfi gate URL 복구 + LS unresolved URL 복구 등 후처리"""
+    db = get_db()
+
+    # 1. DBfi: gate URL 복구 (m.db-sec.co.kr → whub.dbsec.co.kr/pv/gate)
+    from modules.DBfi_19 import DBfi_detail
+    firm_info_19 = FirmInfo(sec_firm_order=19, article_board_order=0)
+
+    records_19 = await db.fetch_all_empty_telegram_url_articles(
+        firm_info=firm_info_19, days_limit=3
+    )
+    if records_19:
+        logger.info(f"[DBfi] {len(records_19)} unresolved → gate URL 복구 시도...")
+        try:
+            updated = await DBfi_detail(articles=records_19, firm_info=firm_info_19, db=db)
+            success = sum(1 for r in updated if r.get("telegram_url", "").startswith("https://whub.dbsec.co.kr/pv/gate"))
+            logger.success(f"[DBfi] {success}/{len(updated)} gate URL 복구 완료")
+        except Exception as e:
+            logger.error(f"[DBfi] post-process failed: {e}")
+
+    # 2. LS: unresolved URL 복구 (LS는 import_ls_artifact.py에서 별도 처리되지만,
+    #    혹시 몰라 fallback)
+    #    → 생략 (import_ls_artifact.py가 처리)
+
+    logger.info("Post-processing complete")
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="All-Firms Artifact Import")
+    parser.add_argument(
+        "--repo",
+        default=os.getenv("GITHUB_REPOSITORY", "liante0904/ssh-reports-scraper"),
+        help="GitHub repository",
+    )
+    parser.add_argument(
+        "--artifact-name",
+        default=os.getenv("ALL_ARTIFACT_NAME", "all-scraped-data"),
+        help="Artifact name",
+    )
+    parser.add_argument(
+        "--json-file",
+        default=None,
+        help="Skip download, use local JSON file",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="DB insert 건너뛰기",
+    )
+    parser.add_argument(
+        "--skip-post-process",
+        action="store_true",
+        help="후처리 건너뛰기",
+    )
+    args = parser.parse_args()
+
+    # 아티팩트 로드
+    if args.json_file:
+        logger.info(f"Loading from local file: {args.json_file}")
+        with open(args.json_file, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not data:
+            logger.error("Empty JSON file")
+            return
+    else:
+        data = download_artifact(args.repo, args.artifact_name)
+        if not data:
+            logger.error("Failed to download artifact")
+            return
+
+    # DB import
+    result = import_all_firms(data, dry_run=args.dry_run)
+
+    # 후처리
+    if not args.skip_post_process and result["inserted"] > 0:
+        await post_process_all()
+
+    logger.info("=== All-Firms Import Complete ===")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/import_ls_artifact.py
+++ b/scripts/import_ls_artifact.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+LS 아티팩트 Import 스크립트
+===========================
+GitHub Actions에서 생성된 LS scrape artifact를 다운로드하여 DB에 import.
+
+1. gh CLI로 최신 ls-scraped-data artifact 다운로드
+2. JSON 파싱
+3. DB key 중복 확인 후 insert
+4. unresolved URL 건들에 대해 reconstruct_msg_url_from_db 후처리
+
+사용법:
+  python3 scripts/import_ls_artifact.py [--repo liante0904/ssh-reports-scraper]
+  
+환경변수:
+  GITHUB_REPOSITORY: artifact를 가져올 리포지토리 (기본: liante0904/ssh-reports-scraper)
+  LS_ARTIFACT_NAME: artifact 이름 (기본: ls-scraped-data)
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timedelta
+from loguru import logger
+
+# 프로젝트 루트 추가
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.logger_util import setup_logger
+setup_logger("import_ls")
+
+from models.db_factory import get_db
+from models.FirmInfo import FirmInfo
+
+
+def download_artifact(repo: str, artifact_name: str = "ls-scraped-data") -> dict | None:
+    """gh CLI로 최신 workflow run의 artifact 다운로드 → JSON 반환"""
+    tmpdir = tempfile.mkdtemp(prefix="ls_artifact_")
+
+    try:
+        # 1. 최신 successful workflow run 찾기
+        logger.info(f"Searching latest successful run for: {repo}")
+        result = subprocess.run(
+            [
+                "gh", "run", "list",
+                "--repo", repo,
+                "--workflow", "scrape-ls.yml",
+                "--status", "success",
+                "--limit", "1",
+                "--json", "databaseId",
+            ],
+            capture_output=True, text=True, check=True,
+        )
+        runs = json.loads(result.stdout)
+        if not runs:
+            logger.error("No successful LS scraper runs found")
+            return None
+
+        run_id = runs[0]["databaseId"]
+        logger.info(f"Found run ID: {run_id}")
+
+        # 2. artifact 다운로드
+        subprocess.run(
+            [
+                "gh", "run", "download",
+                "--repo", repo,
+                str(run_id),
+                "--name", artifact_name,
+                "--dir", tmpdir,
+            ],
+            capture_output=True, text=True, check=True,
+        )
+
+        # 3. JSON 파일 찾기
+        json_files = [f for f in os.listdir(tmpdir) if f.endswith(".json")]
+        if not json_files:
+            logger.error(f"No JSON file found in artifact")
+            return None
+
+        json_path = os.path.join(tmpdir, json_files[0])
+        with open(json_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        logger.info(
+            f"Artifact loaded: {data['count']} articles "
+            f"(resolved={data.get('resolved_urls', 0)}, "
+            f"cdn={data.get('cdn_resolved', 0)})"
+        )
+        return data
+
+    except subprocess.CalledProcessError as e:
+        logger.error(f"gh CLI error: {e.stderr}")
+        return None
+    except Exception as e:
+        logger.error(f"Download failed: {e}")
+        return None
+
+
+def import_to_db(data: dict) -> tuple[int, int]:
+    """아티팩트 데이터를 DB에 import (key 중복 제외)"""
+    articles = data.get("articles", [])
+    if not articles:
+        logger.info("No articles to import")
+        return 0, 0
+
+    db = get_db()
+
+    # LS증권 기존 key 조회 (최근 30일)
+    existing_keys = db.fetch_existing_keys(sec_firm_order=0, days_limit=30)
+
+    # 신규 기사만 필터
+    new_articles = [a for a in articles if a.get("key") and a["key"] not in existing_keys]
+    skipped = len(articles) - len(new_articles)
+    if skipped:
+        logger.info(f"Skipped {skipped} already-existing articles")
+
+    if not new_articles:
+        logger.info("All articles already in DB")
+        return 0, skipped
+
+    # DB insert
+    ins, upd = db.insert_json_data_list(new_articles)
+    logger.success(f"DB Import: {ins} inserted, {upd} updated, {skipped} skipped")
+    return ins, upd
+
+
+async def post_process_unresolved():
+    """telegram_url이 없는 LS 레포트들에 대해 msg URL 복구 시도"""
+    from modules.LS_0 import LS_detail
+
+    db = get_db()
+
+    # unresolved LS articles (telegram_url 없는 것)
+    records = await db.fetch_all_empty_telegram_url_articles(
+        firm_info=FirmInfo(sec_firm_order=0, article_board_order=0),
+        days_limit=3,
+    )
+
+    if not records:
+        logger.info("No unresolved LS articles to post-process")
+        return
+
+    logger.info(f"Post-processing {len(records)} unresolved LS articles...")
+    try:
+        enriched = await LS_detail(articles=records, db=db)
+        resolved = sum(1 for a in enriched if a.get("telegram_url", "").startswith("https://msg.ls-sec.co.kr/"))
+        logger.success(f"Post-process: {resolved}/{len(records)} msg URLs reconstructed")
+
+        # update DB
+        tasks = [
+            db.update_telegram_url(
+                r["report_id"],
+                r["telegram_url"],
+                r.get("article_title"),
+                pdf_url=r.get("pdf_url") or r["telegram_url"],
+            )
+            for r in enriched
+            if r.get("telegram_url")
+        ]
+        if tasks:
+            await asyncio.gather(*tasks)
+
+    except Exception as e:
+        logger.error(f"Post-process failed: {e}")
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="LS Artifact Import")
+    parser.add_argument(
+        "--repo",
+        default=os.getenv("GITHUB_REPOSITORY", "liante0904/ssh-reports-scraper"),
+        help="GitHub repository (owner/name)",
+    )
+    parser.add_argument(
+        "--artifact-name",
+        default=os.getenv("LS_ARTIFACT_NAME", "ls-scraped-data"),
+        help="Artifact name to download",
+    )
+    parser.add_argument(
+        "--json-file",
+        default=None,
+        help="Skip download, use local JSON file instead",
+    )
+    args = parser.parse_args()
+
+    # 아티팩트 로드
+    if args.json_file:
+        logger.info(f"Loading from local file: {args.json_file}")
+        with open(args.json_file, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not data:
+            logger.error("Empty JSON file")
+            return
+    else:
+        data = download_artifact(args.repo, args.artifact_name)
+        if not data:
+            logger.error("Failed to download artifact")
+            return
+
+    # DB import
+    ins, skipped = import_to_db(data)
+
+    # unresolved 건 후처리 (DB 의존 URL 복구)
+    if ins > 0:
+        await post_process_unresolved()
+    else:
+        logger.info("No new inserts, skipping post-process")
+
+    logger.info("=== LS Import Complete ===")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/koreainvestment_backfill.py
+++ b/scripts/koreainvestment_backfill.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""한국투자증권 백필 — 2026-04-13 이후 누락 레포트 전체 수집 → DB import."""
+import os, sys, asyncio
+
+os.environ["KOREAMAX_PAGES"] = "50"  # 50페이지까지 수집 (충분한 커버리지)
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from dotenv import load_dotenv; load_dotenv()
+
+from loguru import logger
+from utils.logger_util import setup_logger
+setup_logger("koreainvestment_backfill")
+
+from modules.Koreainvestment_13 import Koreainvestment_selenium_checkNewArticle
+from models.db_factory import get_db
+
+async def main():
+    logger.info("=== 한국투자증권 백필 시작 (KOREAMAX_PAGES=50) ===")
+    articles = await Koreainvestment_selenium_checkNewArticle()
+    logger.info(f"수집 완료: {len(articles)}건")
+
+    if not articles:
+        logger.warning("수집된 아티클이 없습니다")
+        return
+
+    db = get_db()
+    ins, upd = db.insert_json_data_list(articles)
+    logger.success(f"DB import: {ins} inserted, {upd} updated, {len(articles) - ins - upd} skipped")
+    logger.info("=== 백필 완료 ===")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/koreainvestment_backfill.py
+++ b/scripts/koreainvestment_backfill.py
@@ -23,9 +23,19 @@ async def main():
         logger.warning("수집된 아티클이 없습니다")
         return
 
+    # key 기준 중복 제거 (같은 아티클이 여러 페이지/카테고리에 등장 가능)
+    seen = set()
+    deduped = []
+    for a in articles:
+        k = a.get("key")
+        if k and k not in seen:
+            seen.add(k)
+            deduped.append(a)
+    logger.info(f"중복 제거: {len(articles)} → {len(deduped)}건")
+
     db = get_db()
-    ins, upd = db.insert_json_data_list(articles)
-    logger.success(f"DB import: {ins} inserted, {upd} updated, {len(articles) - ins - upd} skipped")
+    ins, upd = db.insert_json_data_list(deduped)
+    logger.success(f"DB import: {ins} inserted, {upd} updated, {len(deduped) - ins - upd} skipped")
     logger.info("=== 백필 완료 ===")
 
 if __name__ == "__main__":

--- a/scripts/standalone_all_scraper.py
+++ b/scripts/standalone_all_scraper.py
@@ -65,7 +65,7 @@ IMPORT_MAP: dict[str, tuple[str, str, bool]] = {
     "Kiwoom_10":          ("modules.Kiwoom_10",          "Kiwoom_checkNewArticle",            True),
     "DS_11":              ("modules.DS_11",              "DS_checkNewArticle",                False),
     # eugenefn_12: 보류
-    # Koreainvestment_13: Selenium 필요
+    "Koreainvestment_13": ("modules.Koreainvestment_13", "Koreainvestment_selenium_checkNewArticle", True),
     "DAOL_14":            ("modules.DAOL_14",            "DAOL_checkNewArticle",              True),
     "TOSSinvest_15":      ("modules.TOSSinvest_15",      "TOSSinvest_checkNewArticle",        False),
     "Leading_16":         ("modules.Leading_16",         "Leading_checkNewArticle",           True),

--- a/scripts/standalone_all_scraper.py
+++ b/scripts/standalone_all_scraper.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""
+전체 증권사 Standalone Scraper — GitHub Actions 전용
+======================================================
+기존 scraper.py의 checkNewArticle 함수들을 그대로 재사용하여
+전체 증권사 스크래핑을 GitHub Actions에서 수행.
+
+- DB 접근 없이 순수 HTTP 크롤링 결과만 수집
+- 각 증권사별 독립 실행 (한 곳 실패해도 나머지 진행)
+- 결과는 JSON으로 stdout 출력 → artifact 업로드
+
+서버 import 스크립트(import_all_artifact.py)가 JSON을 받아
+DB insert (ON CONFLICT dedup) + 후처리를 담당한다.
+
+제외된 증권사:
+  - LS증권 (LS_0): 별도 scrape-ls.yml로 분리
+  - 한국투자증권 (Koreainvestment_13): Selenium 필요
+  - iMfnsec_18: 보류
+  - eugenefn_12: 세션 만료 이슈 보류
+
+사용법:
+  python3 scripts/standalone_all_scraper.py [--firms 0,1,2] [--timeout 120]
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+import traceback
+from datetime import datetime
+
+# ── 환경 설정 (DB 백엔드를 sqlite로 해도 write는 안 함) ──
+os.environ.setdefault("DB_BACKEND", "sqlite")
+os.environ.setdefault("SQLITE_DB_PATH", "/tmp/telegram_standalone.db")
+os.environ.setdefault("LOG_BASE_DIR", "/tmp")
+os.environ.setdefault("SOCKS_PROXY_URL", "")  # GitHub Actions에서는 프록시 불필요
+os.environ.setdefault("SCRAPER_STALE_DAYS", "30")  # stale 체크 완화
+
+# ── 프로젝트 루트 추가 ──
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from dotenv import load_dotenv
+load_dotenv(override=False)
+
+# 로깅 최소화 (stderr만)
+from loguru import logger
+logger.remove()
+logger.add(sys.stderr, level="INFO", format="<green>{time:HH:mm:ss}</green> | <level>{level: <8}</level> | {message}")
+
+# ── 모든 checkNewArticle 함수 import ──
+IMPORT_MAP: dict[str, tuple[str, str, bool]] = {
+    # "키": ("모듈경로", "함수명", is_async)
+    "LS_0":               ("modules.LS_0",               "LS_checkNewArticle",               False),
+    "ShinHanInvest_1":    ("modules.ShinHanInvest_1",    "ShinHanInvest_checkNewArticle",     True),
+    "NHQV_2":             ("modules.NHQV_2",             "NHQV_checkNewArticle",              True),
+    "HANA_3":             ("modules.HANA_3",             "HANA_checkNewArticle",              True),
+    "KBsec_4":            ("modules.KBsec_4",            "KB_checkNewArticle",                True),
+    "Samsung_5":          ("modules.Samsung_5",          "Samsung_checkNewArticle",           False),
+    "Sangsanginib_6":     ("modules.Sangsanginib_6",     "Sangsanginib_checkNewArticle",      True),
+    "Shinyoung_7":        ("modules.Shinyoung_7",        "Shinyoung_checkNewArticle",         False),
+    "Miraeasset_8":       ("modules.Miraeasset_8",       "Miraeasset_checkNewArticle",        False),
+    "Hmsec_9":            ("modules.Hmsec_9",            "Hmsec_checkNewArticle",             False),
+    "Kiwoom_10":          ("modules.Kiwoom_10",          "Kiwoom_checkNewArticle",            True),
+    "DS_11":              ("modules.DS_11",              "DS_checkNewArticle",                False),
+    # eugenefn_12: 보류
+    # Koreainvestment_13: Selenium 필요
+    "DAOL_14":            ("modules.DAOL_14",            "DAOL_checkNewArticle",              True),
+    "TOSSinvest_15":      ("modules.TOSSinvest_15",      "TOSSinvest_checkNewArticle",        False),
+    "Leading_16":         ("modules.Leading_16",         "Leading_checkNewArticle",           True),
+    "Daeshin_17":         ("modules.Daeshin_17",         "Daeshin_checkNewArticle",           True),
+    # iMfnsec_18: 보류
+    "DBfi_19":            ("modules.DBfi_19",            "DBfi_checkNewArticle",              True),
+    "MERITZ_20":          ("modules.MERITZ_20",          "MERITZ_checkNewArticle",            True),
+    "Hanwhawm_21":        ("modules.Hanwhawm_21",        "Hanwha_checkNewArticle",            True),
+    "Hygood_22":          ("modules.Hygood_22",          "Hanyang_checkNewArticle",           True),
+    "BNKfn_23":           ("modules.BNKfn_23",           "BNK_checkNewArticle",               True),
+    "Kyobo_24":           ("modules.Kyobo_24",           "Kyobo_checkNewArticle",             True),
+    "IBKs_25":            ("modules.IBKs_25",            "IBK_checkNewArticle",               True),
+    "SKS_26":             ("modules.SKS_26",             "Sks_checkNewArticle",               False),
+    "Yuanta_27":          ("modules.Yuanta_27",          "Yuanta_checkNewArticle",            True),
+}
+
+# LS는 별도 처리하므로 제외 (하지만 테스트용으로 --firms 옵션으로 포함 가능)
+SKIP_FIRMS = {"LS_0"}  # LS는 scrape-ls.yml에서 처리
+
+
+def import_function(module_path: str, func_name: str):
+    """동적 import → callable 반환"""
+    import importlib
+    mod = importlib.import_module(module_path)
+    return getattr(mod, func_name)
+
+
+def run_sync_scraper(name: str, func, timeout: int) -> dict:
+    """동기 스크래퍼 실행 → 결과 dict"""
+    t0 = time.time()
+    try:
+        logger.info(f"[{name}] 시작...")
+        result = func()
+        elapsed = time.time() - t0
+        count = len(result) if isinstance(result, list) else 0
+        logger.success(f"[{name}] 완료: {count}건 ({elapsed:.1f}s)")
+        return {
+            "name": name,
+            "status": "success",
+            "count": count,
+            "elapsed_sec": round(elapsed, 1),
+            "articles": result if isinstance(result, list) else [],
+        }
+    except Exception as e:
+        elapsed = time.time() - t0
+        logger.error(f"[{name}] 실패: {e} ({elapsed:.1f}s)")
+        return {
+            "name": name,
+            "status": "error",
+            "error": str(e),
+            "traceback": traceback.format_exc(),
+            "elapsed_sec": round(elapsed, 1),
+            "articles": [],
+        }
+
+
+async def run_async_scraper(name: str, func, timeout: int) -> dict:
+    """비동기 스크래퍼 실행 → 결과 dict"""
+    t0 = time.time()
+    try:
+        logger.info(f"[{name}] 시작 (async)...")
+        result = func()
+        if asyncio.iscoroutine(result):
+            result = await asyncio.wait_for(result, timeout=timeout)
+        elapsed = time.time() - t0
+        count = len(result) if isinstance(result, list) else 0
+        logger.success(f"[{name}] 완료: {count}건 ({elapsed:.1f}s)")
+        return {
+            "name": name,
+            "status": "success",
+            "count": count,
+            "elapsed_sec": round(elapsed, 1),
+            "articles": result if isinstance(result, list) else [],
+        }
+    except asyncio.TimeoutError:
+        elapsed = time.time() - t0
+        logger.error(f"[{name}] 타임아웃 ({timeout}s)")
+        return {"name": name, "status": "timeout", "elapsed_sec": round(elapsed, 1), "articles": []}
+    except Exception as e:
+        elapsed = time.time() - t0
+        logger.error(f"[{name}] 실패: {e} ({elapsed:.1f}s)")
+        return {
+            "name": name,
+            "status": "error",
+            "error": str(e),
+            "traceback": traceback.format_exc(),
+            "elapsed_sec": round(elapsed, 1),
+            "articles": [],
+        }
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="전체 증권사 Standalone Scraper")
+    parser.add_argument("--firms", type=str, default=None,
+                        help="쉼표로 구분된 증권사 키 목록 (예: 'BNKfn_23,HANA_3'). 기본: 전체")
+    parser.add_argument("--timeout", type=int, default=120,
+                        help="비동기 함수당 타임아웃(초) (기본: 120)")
+    parser.add_argument("--skip-ls", action="store_true", default=True,
+                        help="LS증권 제외 (기본: True)")
+    args = parser.parse_args()
+
+    # 대상 증권사 결정
+    if args.firms:
+        target_firms = [k.strip() for k in args.firms.split(",") if k.strip() in IMPORT_MAP]
+    else:
+        target_firms = [k for k in IMPORT_MAP if k not in (SKIP_FIRMS if args.skip_ls else set())]
+
+    logger.info(f"대상 증권사: {len(target_firms)}개")
+    for f in target_firms:
+        logger.info(f"  - {f}")
+
+    # ── import 확인 ──
+    sync_funcs: list[tuple[str, callable]] = []
+    async_funcs: list[tuple[str, callable]] = []
+
+    for key in target_firms:
+        module_path, func_name, is_async = IMPORT_MAP[key]
+        try:
+            func = import_function(module_path, func_name)
+            if is_async:
+                async_funcs.append((key, func))
+            else:
+                sync_funcs.append((key, func))
+            logger.debug(f"  {key}: import OK")
+        except Exception as e:
+            logger.error(f"  {key}: import 실패 - {e}")
+
+    results: list[dict] = []
+
+    # ── Phase 1: 동기 스크래퍼 ──
+    logger.info(f"\n=== Phase 1: Sync Scrapers ({len(sync_funcs)}개) ===")
+    for name, func in sync_funcs:
+        result = run_sync_scraper(name, func, args.timeout)
+        results.append(result)
+        time.sleep(1)  # polite delay
+
+    # ── Phase 2: 비동기 스크래퍼 ──
+    logger.info(f"\n=== Phase 2: Async Scrapers ({len(async_funcs)}개) ===")
+    tasks = [run_async_scraper(name, func, args.timeout) for name, func in async_funcs]
+    async_results = await asyncio.gather(*tasks)
+    results.extend(async_results)
+
+    # ── 집계 ──
+    total_articles = 0
+    success_firms = 0
+    failed_firms = 0
+
+    for r in results:
+        if r["status"] == "success":
+            success_firms += 1
+            total_articles += r["count"]
+        else:
+            failed_firms += 1
+
+    logger.info(f"\n=== 최종 집계 ===")
+    logger.info(f"성공: {success_firms}, 실패: {failed_firms}, 총 아티클: {total_articles}")
+
+    output = {
+        "scraped_at": datetime.now().isoformat(),
+        "source": "github-actions",
+        "total_firms": len(results),
+        "success_firms": success_firms,
+        "failed_firms": failed_firms,
+        "total_articles": total_articles,
+        "firms": results,
+    }
+
+    print(json.dumps(output, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/standalone_ls_scraper.py
+++ b/scripts/standalone_ls_scraper.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""
+LS증권 Standalone Scraper — GitHub Actions 전용
+================================================
+- LS증권 목록 2페이지 + 상세 페이지 스크래핑
+- DB 접근 없이 순수 HTTP 크롤링만 수행
+- 결과는 JSON으로 stdout 출력 (artifact 업로드용)
+
+서버 측 import 스크립트(import_ls_artifact.py)가 이 JSON을 받아
+DB insert + msg URL 복구(reconstruct_msg_url_from_db) 등
+DB 의존적 후처리를 담당한다.
+
+사용법:
+  python3 scripts/standalone_ls_scraper.py [--max-pages 2] [--no-detail]
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import sys
+import time
+import traceback
+from datetime import datetime, timedelta
+from typing import Optional
+from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
+
+import aiohttp
+import requests
+from bs4 import BeautifulSoup
+
+# ---------------------------------------------------------------------------
+# 상수
+# ---------------------------------------------------------------------------
+SEC_FIRM_ORDER = 0
+FIRM_NM = "LS증권"
+
+BOARD_URLS = [
+    "https://www.ls-sec.co.kr/EtwFrontBoard/boardCntsList.jsp?board_no=105&virtual_no=&page=1",  # 기업분석
+    "https://www.ls-sec.co.kr/EtwFrontBoard/boardCntsList.jsp?board_no=100&virtual_no=&page=1",  # 산업분석
+    "https://www.ls-sec.co.kr/EtwFrontBoard/boardCntsList.jsp?board_no=132&virtual_no=&page=1",  # 투자전략
+    "https://www.ls-sec.co.kr/EtwFrontBoard/boardCntsList.jsp?board_no=108&virtual_no=&page=1",  # Quant
+    "https://www.ls-sec.co.kr/EtwFrontBoard/boardCntsList.jsp?board_no=141&virtual_no=&page=1",  # Credit
+    "https://www.ls-sec.co.kr/EtwFrontBoard/boardCntsList.jsp?board_no=144&virtual_no=&page=1",  # 해외주식
+    "https://www.ls-sec.co.kr/EtwFrontBoard/boardCntsList.jsp?board_no=109&virtual_no=&page=1",  # 시황
+    "https://www.ls-sec.co.kr/EtwFrontBoard/boardCntsList.jsp?board_no=107&virtual_no=&page=1",  # Small cap
+    "https://www.ls-sec.co.kr/EtwFrontBoard/boardCntsList.jsp?board_no=133&virtual_no=&page=1",  # 계량분석
+    "https://www.ls-sec.co.kr/EtwFrontBoard/boardCntsList.jsp?board_no=136&virtual_no=&page=1",  # 파생
+]
+
+BOARD_NAMES = [
+    "기업분석", "산업분석", "투자전략", "Quant", "Credit",
+    "해외주식", "시황", "Small cap", "계량분석", "파생",
+]
+
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/124.0.0.0 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7",
+    "Referer": "https://www.ls-sec.co.kr/",
+}
+
+DETAIL_HEADERS = {
+    **HEADERS,
+    "Connection": "keep-alive",
+}
+
+# ---------------------------------------------------------------------------
+# 유틸
+# ---------------------------------------------------------------------------
+
+def clean_url(url: str) -> str:
+    """board_no, board_seq 필수 파라미터만 남기고 정리"""
+    parsed = urlparse(url)
+    qs = parse_qs(parsed.query)
+    required = {k: qs.get(k, [""])[0] for k in ("board_no", "board_seq")}
+    return urlunparse((parsed.scheme, parsed.netloc, parsed.path, "", urlencode(required), ""))
+
+
+def upload_filename_to_cdn_url(filename: str) -> Optional[str]:
+    """
+    upload filename → msg.ls-sec.co.kr CDN URL 변환
+    패턴: {emp_id}_{seq}_{date}.ext → K_{date}_{emp_id}_{seq}.pdf
+    """
+    basename = os.path.basename(filename)
+    m = re.match(r"^(\d+)_(\d+)_(\d{8})\.", basename)
+    if m:
+        emp_id, seq, date_str = m.group(1), m.group(2), m.group(3)
+        return f"https://msg.ls-sec.co.kr/eum/K_{date_str}_{emp_id}_{seq}.pdf"
+    return None
+
+
+def make_fallback_url(attach_file_name: str, reg_dt: str) -> str:
+    """upload/ fallback URL 생성"""
+    url_param_0 = "B" + reg_dt[:6]
+    safe_name = requests.utils.quote(attach_file_name)
+    return f"https://www.ls-sec.co.kr/upload/EtwBoardData/{url_param_0}/{safe_name}"
+
+
+# ---------------------------------------------------------------------------
+# 목록 스크래핑
+# ---------------------------------------------------------------------------
+
+def fetch_list_page(url: str, retries: int = 3) -> Optional[BeautifulSoup]:
+    """목록 페이지 1회 요청"""
+    for attempt in range(1, retries + 1):
+        try:
+            resp = requests.get(url, headers=HEADERS, verify=False, timeout=30)
+            resp.raise_for_status()
+            return BeautifulSoup(resp.content, "html.parser")
+        except Exception as e:
+            print(f"  [WARN] 목록 페이지 요청 실패 (attempt {attempt}/{retries}): {e}", file=sys.stderr)
+            if attempt < retries:
+                time.sleep(2 * attempt)
+    return None
+
+
+def scrape_list(max_pages: int = 2) -> list[dict]:
+    """LS증권 목록 2페이지 스크래핑 → 기사 기본 정보 리스트"""
+    import urllib3
+    urllib3.disable_warnings()
+
+    articles: list[dict] = []
+    seen_keys: set[str] = set()
+
+    for p in range(1, max_pages + 1):
+        page_has_data = False
+
+        for board_order, base_url in enumerate(BOARD_URLS):
+            target_url = base_url if p == 1 else base_url.replace("&page=1", f"&currPage={p}")
+
+            print(f"  [LIST] board={board_order} page={p} url={target_url[:80]}...", file=sys.stderr)
+            time.sleep(2)  # polite delay
+
+            soup = fetch_list_page(target_url)
+            if not soup:
+                continue
+
+            rows = soup.select("#contents > table > tbody > tr")
+            print(f"  [LIST] board={board_order} page={p} → {len(rows)} rows", file=sys.stderr)
+
+            for row in rows:
+                try:
+                    cells = row.select("td")
+                    if len(cells) < 4:
+                        continue
+
+                    writer = cells[2].get_text(strip=True)
+                    str_date = cells[3].get_text(strip=True)
+                    a_tag = row.select_one("a")
+                    if not a_tag:
+                        continue
+
+                    raw_href = a_tag["href"].replace("amp;", "")
+                    article_url = "https://www.ls-sec.co.kr/EtwFrontBoard/" + raw_href
+                    key = clean_url(article_url).replace("&currPage=1", "")
+
+                    if key in seen_keys:
+                        continue
+                    seen_keys.add(key)
+
+                    title_text = a_tag.get_text(strip=True)
+                    title = title_text[title_text.find("]") + 1:].strip() if "]" in title_text else title_text
+
+                    articles.append({
+                        "sec_firm_order": SEC_FIRM_ORDER,
+                        "article_board_order": board_order,
+                        "board_name": BOARD_NAMES[board_order],
+                        "firm_nm": FIRM_NM,
+                        "reg_dt": re.sub(r"[-./]", "", str_date),
+                        "article_title": title,
+                        "writer": writer,
+                        "key": key,
+                        "list_article_url": article_url,
+                        "article_url": "",
+                        "download_url": "",
+                        "telegram_url": "",
+                        "pdf_url": "",
+                        "save_time": datetime.now().isoformat(),
+                    })
+                    page_has_data = True
+                except Exception as e:
+                    print(f"  [WARN] row parse error: {e}", file=sys.stderr)
+
+        if not page_has_data:
+            print(f"  [LIST] page={p} empty, stopping pagination", file=sys.stderr)
+            break
+
+    return articles
+
+
+# ---------------------------------------------------------------------------
+# 상세 페이지 스크래핑
+# ---------------------------------------------------------------------------
+
+async def fetch_detail(session: aiohttp.ClientSession, url: str, retries: int = 3) -> Optional[str]:
+    """상세 페이지 HTML 요청"""
+    for attempt in range(1, retries + 1):
+        try:
+            async with session.get(url, headers=DETAIL_HEADERS, timeout=aiohttp.ClientTimeout(total=30)) as resp:
+                resp.raise_for_status()
+                return await resp.text()
+        except Exception as e:
+            print(f"  [WARN] detail fetch attempt {attempt}/{retries}: {e}", file=sys.stderr)
+            if attempt < retries:
+                await asyncio.sleep(2 * attempt)
+    return None
+
+
+async def probe_url(session: aiohttp.ClientSession, url: str, timeout: int = 10) -> bool:
+    """HEAD 요청으로 URL 유효성 검사"""
+    try:
+        async with session.head(url, headers=HEADERS, timeout=aiohttp.ClientTimeout(total=timeout)) as resp:
+            return resp.status == 200
+    except Exception:
+        return False
+
+
+async def process_detail_article(
+    session: aiohttp.ClientSession,
+    article: dict,
+    sem: asyncio.Semaphore,
+) -> dict:
+    """기사 1건의 상세 페이지를 가져와 제목/작성자/첨부파일 URL 추출"""
+    async with sem:
+        detail_url = article["list_article_url"]
+
+        # PDF direct URL이면 즉시 할당
+        if ".pdf" in detail_url.lower():
+            article["article_url"] = detail_url
+            article["telegram_url"] = detail_url
+            article["pdf_url"] = detail_url
+            article["download_url"] = detail_url
+            return article
+
+        html = await fetch_detail(session, detail_url)
+        if not html:
+            return article
+
+        soup = BeautifulSoup(html, "html.parser")
+        trs = soup.select("tr")
+        attach_file_name = ""
+
+        for tr in trs:
+            th = tr.select_one("th")
+            td = tr.select_one("td")
+            if not th or not td:
+                continue
+
+            th_text = th.get_text(strip=True)
+            td_text = td.get_text(strip=True)
+
+            if th_text == "제목":
+                article["article_title"] = td_text
+            elif th_text == "필명" and td_text:
+                article["writer"] = td_text
+            elif th_text == "첨부파일":
+                # 업로드 파일명 추출
+                for a_tag in tr.select("td a"):
+                    txt = a_tag.get_text(strip=True)
+                    if re.search(r"\d+_\d+_\d{8}\.\w+$", txt):
+                        attach_file_name = txt
+                        break
+                # img alt/src fallback
+                if not attach_file_name:
+                    img = soup.select_one(
+                        "#contents > div.tbViewCon > div > html > body > p > img, "
+                        "#contents > div.tbViewCon > div > p > img"
+                    )
+                    if img:
+                        attach_file_name = img.get("alt") or os.path.basename(img.get("src", ""))
+
+        # URL 결정
+        resolved_url = ""
+
+        # 1순위: CDN URL (upload filename → msg.ls-sec.co.kr)
+        if attach_file_name:
+            cdn_url = upload_filename_to_cdn_url(attach_file_name)
+            if cdn_url and await probe_url(session, cdn_url):
+                resolved_url = cdn_url
+                print(f"  [DETAIL][CDN] {cdn_url}", file=sys.stderr)
+
+        # 2순위: upload/ fallback
+        if not resolved_url and attach_file_name:
+            resolved_url = make_fallback_url(attach_file_name, article["reg_dt"])
+            print(f"  [DETAIL][fallback] {resolved_url}", file=sys.stderr)
+
+        if resolved_url:
+            article["article_url"] = resolved_url
+            article["telegram_url"] = resolved_url
+            article["pdf_url"] = resolved_url
+            article["download_url"] = resolved_url
+
+        article["ATTACH_FILE_NAME"] = attach_file_name
+        return article
+
+
+async def scrape_detail(articles: list[dict], concurrency: int = 3) -> list[dict]:
+    """모든 기사에 대해 상세 페이지 요청 (비동기 병렬)"""
+    target_articles = [a for a in articles if ".pdf" not in a["list_article_url"].lower()]
+    pdf_articles = [a for a in articles if ".pdf" in a["list_article_url"].lower()]
+
+    if not target_articles:
+        print(f"[DETAIL] {len(pdf_articles)} PDF direct, 0 detail needed", file=sys.stderr)
+        return articles
+
+    print(f"[DETAIL] {len(target_articles)} articles to fetch detail pages (concurrency={concurrency})", file=sys.stderr)
+
+    sem = asyncio.Semaphore(concurrency)
+    connector = aiohttp.TCPConnector(ssl=False, limit=concurrency)
+
+    async with aiohttp.ClientSession(connector=connector) as session:
+        tasks = [process_detail_article(session, a, sem) for a in target_articles]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    for i, result in enumerate(results):
+        if isinstance(result, Exception):
+            print(f"  [ERROR] detail article {i}: {result}", file=sys.stderr)
+            traceback.print_exception(type(result), result, result.__traceback__, file=sys.stderr)
+        else:
+            target_articles[i] = result
+
+    return target_articles + pdf_articles
+
+
+# ---------------------------------------------------------------------------
+# 진단
+# ---------------------------------------------------------------------------
+
+def run_diagnostics():
+    """네트워크 진단"""
+    import socket
+    print("=== Diagnostics ===", file=sys.stderr)
+    for url in [BOARD_URLS[0], "https://msg.ls-sec.co.kr/", "https://www.ls-sec.co.kr/"]:
+        host = urlparse(url).hostname
+        port = urlparse(url).port or 443
+        try:
+            ip = socket.getaddrinfo(host, port, socket.AF_INET, socket.SOCK_STREAM)
+            print(f"  DNS {host}: {ip[0][4][0]}", file=sys.stderr)
+        except Exception as e:
+            print(f"  DNS {host}: FAIL ({e})", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="LS증권 Standalone Scraper")
+    parser.add_argument("--max-pages", type=int, default=2, help="목록 페이지 수 (기본 2)")
+    parser.add_argument("--no-detail", action="store_true", help="상세 페이지 스크래핑 건너뛰기")
+    parser.add_argument("--detail-concurrency", type=int, default=3, help="상세 페이지 동시 요청 수 (기본 3)")
+    args = parser.parse_args()
+
+    import urllib3
+    urllib3.disable_warnings()
+
+    run_diagnostics()
+
+    # ── Phase 1: 목록 스크래핑 ──
+    print(f"\n=== Phase 1: List Scraping (max_pages={args.max_pages}) ===", file=sys.stderr)
+    articles = scrape_list(max_pages=args.max_pages)
+    print(f"[LIST] Total: {len(articles)} articles", file=sys.stderr)
+
+    if not articles:
+        output = {
+            "scraped_at": datetime.now().isoformat(),
+            "source": "github-actions",
+            "count": 0,
+            "articles": [],
+        }
+        print(json.dumps(output, ensure_ascii=False, indent=2))
+        return
+
+    # ── Phase 2: 상세 페이지 스크래핑 ──
+    if not args.no_detail:
+        print(f"\n=== Phase 2: Detail Scraping ===", file=sys.stderr)
+        articles = asyncio.run(scrape_detail(articles, concurrency=args.detail_concurrency))
+
+    # 해결된 URL 통계
+    resolved = sum(1 for a in articles if a.get("telegram_url"))
+    cdn_resolved = sum(1 for a in articles if a.get("telegram_url", "").startswith("https://msg.ls-sec.co.kr/"))
+    print(f"[RESULT] resolved={resolved}/{len(articles)} (CDN={cdn_resolved})", file=sys.stderr)
+
+    output = {
+        "scraped_at": datetime.now().isoformat(),
+        "source": "github-actions",
+        "count": len(articles),
+        "resolved_urls": resolved,
+        "cdn_resolved": cdn_resolved,
+        "articles": articles,
+    }
+
+    # stdout → JSON (artifact)
+    print(json.dumps(output, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/toss_backfill.py
+++ b/scripts/toss_backfill.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""토스증권 백필 — 누락 게시판(코멘트, English) 추가 후 전체 수집 → DB import."""
+import os, sys, asyncio
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from dotenv import load_dotenv; load_dotenv()
+
+from loguru import logger
+from utils.logger_util import setup_logger
+setup_logger("toss_backfill")
+
+from modules.TOSSinvest_15 import TOSSinvest_checkNewArticle
+from models.db_factory import get_db
+
+async def main():
+    logger.info("=== 토스증권 백필 시작 (3개 게시판) ===")
+    articles = TOSSinvest_checkNewArticle()
+    logger.info(f"수집 완료: {len(articles)}건")
+
+    if not articles:
+        logger.warning("수집된 아티클이 없습니다")
+        return
+
+    # key 기준 중복 제거
+    seen = set()
+    deduped = []
+    for a in articles:
+        k = a.get("key")
+        if k and k not in seen:
+            seen.add(k)
+            deduped.append(a)
+    logger.info(f"중복 제거: {len(articles)} → {len(deduped)}건")
+
+    db = get_db()
+    ins, upd = db.insert_json_data_list(deduped)
+    logger.success(f"DB import: {ins} inserted, {upd} updated, {len(deduped) - ins - upd} skipped")
+    logger.info("=== 백필 완료 ===")
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## 변경사항

- 모든 증권사 스크래핑을 GitHub Actions로 이관
- LS/전체 scrape workflow (cron 평일 08:00~18:00)
- 서버 import 스크립트 + scheduler job
- 한국투자증권 Selenium ARM64 fix + 백필
- 토스증권 페이징 + 신규 게시판 + 백필
- 건겅검진 스크립트 (check_firm_health.py)