### PR TITLE
fix: enforce sync scraper timeout and result contracts

### DIFF
--- a/scripts/standalone_all_scraper.py
+++ b/scripts/standalone_all_scraper.py
@@ -29,7 +29,9 @@ DB insert (ON CONFLICT dedup) + 후처리를 담당한다.
 import argparse
 import asyncio
 import json
+import multiprocessing
 import os
+import signal
 import sys
 import time
 import traceback
@@ -122,14 +124,69 @@ def import_function(module_path: str, func_name: str):
     return getattr(mod, func_name)
 
 
+def _sync_worker(func, result_queue) -> None:
+    """Run a sync scraper in an isolated process and report its result."""
+    os.setsid()
+    try:
+        result_queue.put(("ok", func()))
+    except BaseException as exc:
+        result_queue.put(("error", (str(exc), traceback.format_exc())))
+
+
+def _terminate_process_group(process: multiprocessing.Process) -> None:
+    """Terminate a timed-out worker and any descendants it spawned."""
+    if process.pid:
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        try:
+            process.join(timeout=0.5)
+            if process.is_alive():
+                os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    process.join(timeout=0.5)
+
+
 def run_sync_scraper(name: str, func, timeout: int) -> dict:
-    """동기 스크래퍼 실행 → 결과 dict"""
+    """Run a sync scraper with a hard timeout and typed result contract."""
     t0 = time.time()
+    result_queue = multiprocessing.Queue()
+    process = multiprocessing.Process(
+        target=_sync_worker,
+        args=(func, result_queue),
+        daemon=False,
+    )
     try:
         logger.info(f"[{name}] 시작...")
-        result = func()
+        process.start()
+        process.join(timeout=timeout)
+        if process.is_alive():
+            _terminate_process_group(process)
+            elapsed = time.time() - t0
+            logger.error(f"[{name}] 타임아웃 ({timeout}s)")
+            return {"name": name, "status": "timeout", "elapsed_sec": round(elapsed, 1), "articles": []}
+
+        if result_queue.empty():
+            raise RuntimeError(f"worker exited without a result (exitcode={process.exitcode})")
+        outcome, payload = result_queue.get()
+        if outcome == "error":
+            error, stack = payload
+            raise RuntimeError(f"{error}\n{stack}")
+        result = payload
+        if not isinstance(result, list):
+            elapsed = time.time() - t0
+            logger.error(f"[{name}] 잘못된 결과 타입: expected list, got {type(result).__name__}")
+            return {
+                "name": name,
+                "status": "invalid_result",
+                "error": f"expected list, got {type(result).__name__}",
+                "elapsed_sec": round(elapsed, 1),
+                "articles": [],
+            }
         elapsed = time.time() - t0
-        count = len(result) if isinstance(result, list) else 0
+        count = len(result)
         logger.success(f"[{name}] 완료: {count}건 ({elapsed:.1f}s)")
         return {
             "name": name,
@@ -149,6 +206,11 @@ def run_sync_scraper(name: str, func, timeout: int) -> dict:
             "elapsed_sec": round(elapsed, 1),
             "articles": [],
         }
+    finally:
+        if process.is_alive():
+            _terminate_process_group(process)
+        result_queue.close()
+        result_queue.join_thread()
 
 
 async def run_async_scraper(name: str, func, timeout: int) -> dict:

--- a/scripts/standalone_all_scraper.py
+++ b/scripts/standalone_all_scraper.py
@@ -31,6 +31,7 @@ import asyncio
 import json
 import multiprocessing
 import os
+import queue
 import signal
 import sys
 import time
@@ -168,9 +169,12 @@ def run_sync_scraper(name: str, func, timeout: int) -> dict:
             logger.error(f"[{name}] 타임아웃 ({timeout}s)")
             return {"name": name, "status": "timeout", "elapsed_sec": round(elapsed, 1), "articles": []}
 
-        if result_queue.empty():
-            raise RuntimeError(f"worker exited without a result (exitcode={process.exitcode})")
-        outcome, payload = result_queue.get()
+        try:
+            outcome, payload = result_queue.get(timeout=1)
+        except queue.Empty as exc:
+            raise RuntimeError(
+                f"worker exited without a result (exitcode={process.exitcode})"
+            ) from exc
         if outcome == "error":
             error, stack = payload
             raise RuntimeError(f"{error}\n{stack}")

--- a/tests/test_standalone_all_scraper.py
+++ b/tests/test_standalone_all_scraper.py
@@ -3,7 +3,13 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from scripts.standalone_all_scraper import GA_STANDALONE_FIRMS, IMPORT_MAP, select_target_firms
+from scripts.standalone_all_scraper import (
+    GA_STANDALONE_FIRMS,
+    IMPORT_MAP,
+    run_sync_scraper,
+    select_target_firms,
+)
+import time
 
 
 def test_select_target_firms_default_includes_ga_and_ls():
@@ -26,3 +32,24 @@ def test_select_target_firms_explicit_firms_overrides_filters():
     targets = select_target_firms("LS_0,KBsec_4,NO_SUCH", server_only=True, skip_ls=True)
 
     assert targets == ["LS_0", "KBsec_4"]
+
+
+def test_sync_scraper_timeout_terminates_worker():
+    def hangs():
+        time.sleep(10)
+
+    result = run_sync_scraper("test-timeout", hangs, timeout=0.1)
+
+    assert result["status"] == "timeout"
+    assert result["articles"] == []
+
+
+def test_sync_scraper_rejects_scalar_result():
+    def returns_scalar():
+        return {"article": "not-a-list"}
+
+    result = run_sync_scraper("test-invalid", returns_scalar, timeout=2)
+
+    assert result["status"] == "invalid_result"
+    assert "expected list" in result["error"]
+    assert result["articles"] == []


### PR DESCRIPTION
## Summary
- enforce hard timeout for synchronous standalone scrapers
- terminate isolated process groups on timeout
- reject scalar results as `invalid_result`

## Verification
- `bash scripts/verify_ci.sh` -> 309 passed
- targeted lifecycle/contract tests passed
