### PR TITLE
fix: honor environment-specific scraper secrets

### DIFF
--- a/models/ConfigManager.py
+++ b/models/ConfigManager.py
@@ -65,9 +65,18 @@ class ConfigManager:
         return self._get_env_secrets().get("CHANNEL_ID") or self._secrets.get("common", {}).get("TELEGRAM_CHANNEL_ID_REPORT_ALARM")
 
     def get_secret(self, key, default=None):
-        """특정 환경 변수 또는 공통 변수를 가져옵니다."""
+        """Return a secret using explicit environment precedence.
+
+        Precedence is process environment, selected secrets section, then
+        common secrets.  The ``prod`` section remains supported through
+        :meth:`_get_env_secrets` for existing deployments.
+        """
         val = os.getenv(key)
-        if val: return val
+        if val:
+            return val
+        env_value = self._get_env_secrets().get(key)
+        if env_value:
+            return env_value
         return self._secrets.get("common", {}).get(key, default)
 
     def get_urls(self, key, default=None):

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -56,11 +56,56 @@ def test_env_resolves_production(monkeypatch, tmp_path):
     monkeypatch.setenv("ENV", "production")
     config = fresh_config(monkeypatch, tmp_path)
     assert config.ENV == "production"
-
     monkeypatch.setenv("ENV", "prod")
     config = fresh_config(monkeypatch, tmp_path)
     assert config.ENV == "production"
 
+
+def test_get_secret_prefers_selected_environment_over_common(monkeypatch, tmp_path):
+    config = fresh_config(monkeypatch, tmp_path)
+    config._secrets = {
+        "common": {"API_TOKEN": "common"},
+        "dev": {"API_TOKEN": "dev"},
+        "production": {"API_TOKEN": "production"},
+    }
+
+    monkeypatch.setenv("ENV", "dev")
+    config._load_config()
+    config._secrets = {
+        "common": {"API_TOKEN": "common"},
+        "dev": {"API_TOKEN": "dev"},
+        "production": {"API_TOKEN": "production"},
+    }
+    assert config.get_secret("API_TOKEN") == "dev"
+
+    monkeypatch.setenv("ENV", "production")
+    config._load_config()
+    config._secrets = {
+        "common": {"API_TOKEN": "common"},
+        "dev": {"API_TOKEN": "dev"},
+        "production": {"API_TOKEN": "production"},
+    }
+    assert config.get_secret("API_TOKEN") == "production"
+
+
+def test_get_secret_process_environment_overrides_file(monkeypatch, tmp_path):
+    config = fresh_config(monkeypatch, tmp_path)
+    config._secrets = {"common": {"API_TOKEN": "common"}, "dev": {"API_TOKEN": "dev"}}
+    monkeypatch.setenv("ENV", "dev")
+    config._load_config()
+    monkeypatch.setenv("API_TOKEN", "process")
+
+    assert config.get_secret("API_TOKEN") == "process"
+
+
+def test_get_secret_missing_returns_default(monkeypatch, tmp_path):
+    config = fresh_config(monkeypatch, tmp_path)
+    config._secrets = {"common": {}, "dev": {}}
+    monkeypatch.setenv("ENV", "dev")
+    config._load_config()
+
+    assert config.get_secret("MISSING_SECRET") is None
+    assert config.get_secret("MISSING_SECRET", "fallback") == "fallback"
 
 def test_fallback_to_legacy_prod_section(monkeypatch, tmp_path):
     # secrets.json에 'prod'만 있고 'production'이 없는 상태 구현


### PR DESCRIPTION
## Summary
- enforce process > selected environment > common > default secret precedence
- preserve production/prod compatibility
- add focused precedence tests

## Verification
- focused ConfigManager/FirmInfo tests: 21 passed
- pre-push checks passed
