### PR TITLE
fix: iterate active firms without contiguous ID assumptions

### DIFF
--- a/models/FirmInfo.py
+++ b/models/FirmInfo.py
@@ -26,6 +26,13 @@ class FirmInfo(metaclass=MetaFirmInfo):
     _metadata_source = None  # "postgres" | "static" — signals DB reliability
 
     @classmethod
+    def iter_active_firm_ids(cls) -> list[int]:
+        """Return loaded firm IDs without assuming contiguous database IDs."""
+        if not cls._is_loaded:
+            cls.load_data_from_db()
+        return sorted(cls._firm_data)
+
+    @classmethod
     def load_data_from_db(cls):
         if cls._is_loaded:
             return

--- a/models/firm_utils.py
+++ b/models/firm_utils.py
@@ -27,6 +27,11 @@ def all_firm_names() -> list[str]:
     return FirmInfo.firm_names
 
 
+def iter_active_firm_ids() -> list[int]:
+    """Return active firm IDs from loaded metadata, preserving gaps."""
+    return FirmInfo.iter_active_firm_ids()
+
+
 def telegram_update_required(firm_id: int) -> bool:
     """텔레그램 발송 필요 여부."""
     return FirmInfo(firm_id, 0).telegram_update_required

--- a/scraper.py
+++ b/scraper.py
@@ -140,13 +140,13 @@ def log_scraper_health(name, rows):
 async def enrich_data():
     logger.info("Starting data enrichment process...")
     db = get_db()
-    from models.firm_utils import all_firm_names, firm_name as _firm_name, telegram_update_required
+    from models.firm_utils import iter_active_firm_ids, firm_name as _firm_name, telegram_update_required
     import pytz
     from datetime import datetime
     kst_hour = datetime.now(pytz.timezone('Asia/Seoul')).hour
     is_idle_time = kst_hour >= 20 or kst_hour < 6
 
-    for firm_id in range(len(all_firm_names())):
+    for firm_id in iter_active_firm_ids():
         name = _firm_name(firm_id)
         if not (name and telegram_update_required(firm_id)):
             continue

--- a/tests/test_firm_info.py
+++ b/tests/test_firm_info.py
@@ -50,6 +50,17 @@ class TestFirmInfoGaEnabled:
         fi.set_firm_id(4)
         assert fi.ga_enabled is False  # fallback always False
 
+    def test_iter_active_firm_ids_preserves_database_gaps(self):
+        from models.FirmInfo import FirmInfo
+        FirmInfo._firm_data = {
+            2: {"name": "NH"},
+            7: {"name": "Shinyoung"},
+            19: {"name": "DB"},
+        }
+        FirmInfo._is_loaded = True
+
+        assert FirmInfo.iter_active_firm_ids() == [2, 7, 19]
+
 
 class TestFirmUtilsGaEnabled:
     """firm_utils.ga_enabled() 함수 테스트."""


### PR DESCRIPTION
## Summary
- add explicit active firm ID iteration API
- remove `range(len(all_firm_names()))` runtime assumption
- preserve static fallback and add gapped-ID regression test

## Verification
- focused suite: 51 passed
- pre-push checks passed
