### PR TITLE
fix: make ssh-library checkout path explicit

### DIFF
--- a/run/test_db_scheduler.py
+++ b/run/test_db_scheduler.py
@@ -18,10 +18,14 @@
 """
 
 import os
+from pathlib import Path
 import sys
 
 # ssh_library 및 scraper 루트 경로 추가
-sys.path.insert(0, os.path.expanduser("~/workspace/lib/ssh_library"))
+repo_root = Path(__file__).resolve().parents[1]
+default_library = repo_root.parents[3] / "lib" / "ssh_library"
+library_path = Path(os.environ.get("SSH_LIBRARY_PATH", default_library))
+sys.path.insert(0, str(library_path.parent if library_path.name == "ssh_library" else library_path))
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from ssh_library.modules.scheduler import SchedulerManager, _now_kst

--- a/tests/test_db_factory.py
+++ b/tests/test_db_factory.py
@@ -1,13 +1,16 @@
+import os
 import sys
 from pathlib import Path
 
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
-LIB_DIR = ROOT.parents[3] / "lib"
+LIB_DIR = Path(os.environ.get("SSH_LIBRARY_PATH", ROOT.parents[3] / "lib" / "ssh_library"))
 sys.path.append(str(ROOT))
 if (LIB_DIR / "ssh_library").exists():
-    sys.path.append(str(LIB_DIR / "ssh_library"))
+    sys.path.append(str(LIB_DIR))
+elif (LIB_DIR / "__init__.py").exists():
+    sys.path.append(str(LIB_DIR.parent))
 
 
 def test_get_db_default_uses_sec_reports_manager(monkeypatch):
@@ -20,7 +23,7 @@ def test_get_db_default_uses_sec_reports_manager(monkeypatch):
 
 
 def test_get_db_ssh_library_backend(monkeypatch):
-    if not (LIB_DIR / "ssh_library").exists():
+    if not ((LIB_DIR / "ssh_library").exists() or (LIB_DIR / "__init__.py").exists()):
         pytest.skip("ssh-library checkout is not available")
 
     monkeypatch.setenv("DB_BACKEND", "ssh_library")

--- a/tests/test_sec_reports_manager.py
+++ b/tests/test_sec_reports_manager.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 import asyncio
@@ -5,10 +6,12 @@ from datetime import datetime
 
 
 ROOT = Path(__file__).resolve().parents[1]
-LIB_DIR = ROOT.parents[3] / "lib"
+LIB_DIR = Path(os.environ.get("SSH_LIBRARY_PATH", ROOT.parents[3] / "lib" / "ssh_library"))
 sys.path.append(str(ROOT))
 if (LIB_DIR / "ssh_library").exists():
-    sys.path.append(str(LIB_DIR / "ssh_library"))
+    sys.path.append(str(LIB_DIR))
+elif (LIB_DIR / "__init__.py").exists():
+    sys.path.append(str(LIB_DIR.parent))
 
 
 class FakeCursor:


### PR DESCRIPTION
Use SSH_LIBRARY_PATH consistently across local and CI environments. Focused tests: 12 passed.