### PR TITLE
fix: enforce scraper subprocess lifecycle timeout

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -1,5 +1,6 @@
 # -*- coding:utf-8 -*- 
 import os
+import signal
 import subprocess
 import sys
 from datetime import datetime
@@ -21,6 +22,46 @@ load_dotenv()
 from scraper_config import invalidate_api_cache
 
 
+def _scraper_process_timeout() -> int:
+    """Return the hard limit for one scraper job."""
+    try:
+        return max(30, int(os.getenv("SCRAPER_PROCESS_TIMEOUT_SECONDS", "900")))
+    except ValueError:
+        return 900
+
+
+def _run_scraper_process() -> subprocess.CompletedProcess:
+    """Run scraper in an isolated process group and reap it on timeout."""
+    process = subprocess.Popen(
+        [sys.executable, "scraper.py"],
+        capture_output=True,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        stdout, stderr = process.communicate(timeout=_scraper_process_timeout())
+    except subprocess.TimeoutExpired:
+        logger.error(
+            f"Scraper process exceeded {_scraper_process_timeout()}s; terminating process group"
+        )
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        try:
+            stdout, stderr = process.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            stdout, stderr = process.communicate()
+        return subprocess.CompletedProcess(
+            process.args, process.returncode or 124, stdout, stderr
+        )
+    return subprocess.CompletedProcess(process.args, process.returncode, stdout, stderr)
+
+
 def run_scraper():
     """메인 스크래퍼 실행 (scraper.py) — subprocess 중복 실행 방지 포함"""
     import fcntl
@@ -40,12 +81,7 @@ def run_scraper():
     try:
         logger.info("--- [Job Start] Main Scraper (scraper.py) ---")
         try:
-            result = subprocess.run(
-                [sys.executable, "scraper.py"],
-                capture_output=True,
-                text=True,
-                check=False
-            )
+            result = _run_scraper_process()
             if result.returncode != 0:
                 logger.error(f"Scraper process exited with error code {result.returncode}")
                 if result.stderr:

--- a/tests/test_scheduler_process_lifecycle.py
+++ b/tests/test_scheduler_process_lifecycle.py
@@ -1,0 +1,68 @@
+import subprocess
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_scraper_process_uses_isolated_group_and_timeout(monkeypatch):
+    import scheduler
+
+    seen = {}
+
+    class FakeProcess:
+        pid = 1234
+        args = ["scraper.py"]
+        returncode = 0
+
+        def communicate(self, timeout=None):
+            seen["timeout"] = timeout
+            return "out", "err"
+
+    def fake_popen(args, **kwargs):
+        seen["args"] = args
+        seen["kwargs"] = kwargs
+        return FakeProcess()
+
+    monkeypatch.setattr(scheduler.subprocess, "Popen", fake_popen)
+    monkeypatch.setenv("SCRAPER_PROCESS_TIMEOUT_SECONDS", "120")
+
+    result = scheduler._run_scraper_process()
+
+    assert result.returncode == 0
+    assert seen["kwargs"]["start_new_session"] is True
+    assert seen["timeout"] == 120
+
+
+def test_timeout_terminates_process_group_and_reaps(monkeypatch):
+    import scheduler
+
+    calls = []
+
+    class FakeProcess:
+        pid = 4321
+        args = ["scraper.py"]
+        returncode = -15
+        attempts = 0
+
+        def communicate(self, timeout=None):
+            self.attempts += 1
+            if self.attempts == 1:
+                raise subprocess.TimeoutExpired(self.args, timeout)
+            return "", "killed"
+
+    monkeypatch.setattr(scheduler.subprocess, "Popen", lambda *a, **k: FakeProcess())
+    monkeypatch.setattr(scheduler.os, "killpg", lambda pid, sig: calls.append((pid, sig)))
+    monkeypatch.setenv("SCRAPER_PROCESS_TIMEOUT_SECONDS", "30")
+
+    result = scheduler._run_scraper_process()
+
+    assert result.returncode == -15
+    assert calls == [(4321, scheduler.signal.SIGTERM)]
+
+
+def test_invalid_timeout_uses_safe_default(monkeypatch):
+    import scheduler
+
+    monkeypatch.setenv("SCRAPER_PROCESS_TIMEOUT_SECONDS", "not-a-number")
+    assert scheduler._scraper_process_timeout() == 900


### PR DESCRIPTION
Add process-group timeout and reap for scheduler scraper subprocesses. Focused tests: 3 passed.