### PR TITLE
refactor: preserve async scraper tracebacks

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -246,6 +246,7 @@ async def call_async_scraper(func):
     except asyncio.TimeoutError:
         return name, None, f"Async Scraper Timeout ({name}): {SCRAPER_ASYNC_TIMEOUT_SECONDS}s"
     except Exception as e:
+        logger.exception(f"Async scraper failure ({name})")
         return name, None, f"Async Scraper Error ({name}): {e}"
 
 

--- a/tests/test_scraper_error_logging.py
+++ b/tests/test_scraper_error_logging.py
@@ -1,0 +1,27 @@
+"""call_async_scraper must log full traceback on scraper failure."""
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+@pytest.mark.asyncio
+async def test_call_async_scraper_logs_exception_preserves_return(monkeypatch):
+    from scraper import call_async_scraper
+
+    async def broken():
+        raise KeyError("payload")
+
+    fake_log = mock.Mock()
+    monkeypatch.setattr("scraper.logger", fake_log)
+
+    name, result, error = await call_async_scraper(broken)
+
+    assert result is None
+    assert "payload" in error
+    # logger.exception() must be called to preserve full traceback in logs
+    assert fake_log.exception.called, "logger.exception() not called — traceback lost"


### PR DESCRIPTION
## Problem
`call_async_scraper()` converted unexpected exceptions to a short error string without logging the traceback, hiding the exception type and source line from production diagnostics.

## Change
- log unexpected async scraper failures with `logger.exception()`
- preserve the existing `(name, result, error)` return contract
- add one 27-line focused regression test

## Validation
- `uv run pytest -q tests/test_scraper_error_logging.py` — 1 passed
- `python3 -m py_compile scraper.py tests/test_scraper_error_logging.py` — passed
- `git diff --check` — passed
- push verification hook — passed