### PR TITLE
fix: use Popen stdout/stderr pipes instead of capture_output

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -34,7 +34,8 @@ def _run_scraper_process() -> subprocess.CompletedProcess:
     """Run scraper in an isolated process group and reap it on timeout."""
     process = subprocess.Popen(
         [sys.executable, "scraper.py"],
-        capture_output=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
         start_new_session=True,
     )


### PR DESCRIPTION
## Problem

The watchdog fired an `ERROR` alert on every scheduled scraper run:

```
Execution Error: Popen.__init__() got an unexpected keyword argument 'capture_output'
```

`_run_scraper_process()` passed `capture_output=True` to `subprocess.Popen(...)`, but that kwarg only exists on `subprocess.run()`. As a result the main scraper never actually executed — it raised immediately and the exception was logged as ERROR, which the watchdog correctly surfaced each cycle.

## Fix

Pass `stdout=subprocess.PIPE, stderr=subprocess.PIPE` so `process.communicate()` captures output as intended. No behavioral change beyond making the process actually start.

## Verification

- Reproduced the exact same `Popen` call locally — raises before the change, succeeds after.
- `python3 -m py_compile scheduler.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)