### PR TITLE
refactor: preserve GA lookup exception context

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -68,7 +68,7 @@ def _filter_ga_enabled(mapping: dict) -> dict:
             return dict(mapping)
         return {order: func for order, func in mapping.items() if order in enabled}
     except Exception:
-        logger.warning("ga_enabled lookup failed, falling back to all GA candidates")
+        logger.exception("ga_enabled lookup failed, falling back to all GA candidates")
         return dict(mapping)
 
 def _is_full_scrape_hour():

--- a/tests/test_ga_enabled_error_context.py
+++ b/tests/test_ga_enabled_error_context.py
@@ -1,0 +1,29 @@
+import builtins, sys
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def test_filter_ga_enabled_logs_exception_preserves_fallback(monkeypatch):
+    from scraper import _filter_ga_enabled
+
+    orig_import = builtins.__import__
+
+    def block_firm_utils(name, *a, **kw):
+        if "firm_utils" in name:
+            raise ImportError("DB unreachable")
+        return orig_import(name, *a, **kw)
+
+    monkeypatch.setattr(builtins, "__import__", block_firm_utils)
+    fake_log = mock.Mock()
+    monkeypatch.setattr("scraper.logger", fake_log)
+
+    mapping = {5: lambda: None, 9: lambda: None}
+    result = _filter_ga_enabled(mapping)
+
+    assert result == mapping
+    fake_log.exception.assert_called_once_with(
+        "ga_enabled lookup failed, falling back to all GA candidates"
+    )


### PR DESCRIPTION
## Problem
`_filter_ga_enabled()` runs on every scraper cycle. When its lookup fails, it falls back to all GA candidates but logged only a generic warning, hiding the root exception and making a potentially unsafe fail-open path difficult to diagnose.

## Change
- replace the generic warning with `logger.exception()`
- preserve the existing fallback mapping and public behavior
- add one 29-line focused regression test

## Validation
- `uv run pytest -q tests/test_ga_enabled_error_context.py` — 1 passed
- `python3 -m py_compile scraper.py tests/test_ga_enabled_error_context.py` — passed
- `git diff --check` — passed
- push verification hook — passed