### PR TITLE
refactor: expose Toss scraper request failures

### DIFF
--- a/scrapers/toss_core.py
+++ b/scrapers/toss_core.py
@@ -17,7 +17,9 @@ def scrape_toss(cfg: dict) -> list[dict]:
             try:
                 resp = requests.get(purl, headers=cfg["headers"], verify=False, timeout=30)
                 resp.raise_for_status(); jres = resp.json()
-            except Exception: break
+            except Exception as exc:
+                print(f"[toss] request failed page={page} {type(exc).__name__}: {exc}", file=sys.stderr)
+                break
             items = jres.get("result", {}).get("list", [])
             if not items: break
             if total_pages is None: total_pages = jres.get("result", {}).get("pagingParam", {}).get("totalPageCount", 1)

--- a/tests/test_toss_error_context.py
+++ b/tests/test_toss_error_context.py
@@ -1,0 +1,20 @@
+"""Verify toss_core logs diagnostic on request failure."""
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def test_scrape_toss_logs_error_preserves_return(capsys, monkeypatch):
+    from scrapers import toss_core
+
+    fail = lambda *a, **kw: (_ for _ in ()).throw(ConnectionError("no route"))
+    monkeypatch.setattr(toss_core.requests, "get", fail)
+
+    result = toss_core.scrape_toss({
+        "urls": ["https://example.test/toss"], "headers": {}, "item_keys": {},
+    })
+
+    assert result == []
+    assert "ConnectionError: no route" in capsys.readouterr().err


### PR DESCRIPTION
## Change
- preserve exception type and message when Toss pagination stops on request/HTTP/JSON failure
- keep existing break, pagination, payload, and return behavior
- add one 20-line focused test

## Validation
- focused test: 1 passed
- py_compile: passed
- diff check and push hook: passed