### PR TITLE
refactor: expose DBfi recovery failures

### DIFF
--- a/modules/DBfi_19.py
+++ b/modules/DBfi_19.py
@@ -349,7 +349,15 @@ async def DBfi_enrich_and_persist_details(articles, firm_info=None, db=None):
             resp = requests.post(url, data=data, **kwargs)
             resp.raise_for_status()
             return resp
-        except Exception:
+        except requests.HTTPError as exc:
+            status = exc.response.status_code if exc.response is not None else "?"
+            logger.warning(f"DBfi POST failed HTTP {status} ({type(exc).__name__})")
+            return None
+        except requests.RequestException as exc:
+            logger.warning(f"DBfi POST failed ({type(exc).__name__})")
+            return None
+        except Exception as exc:
+            logger.warning(f"DBfi POST failed ({type(exc).__name__})")
             return None
 
     def _fetch_key_url_sync(key_url):

--- a/tests/test_dbfi_post_error_context.py
+++ b/tests/test_dbfi_post_error_context.py
@@ -1,0 +1,29 @@
+"""Verify DBfi POST failure logs type, never exception text."""
+import sys
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def test_dbfi_post_failure_logs_type_not_private_text(monkeypatch):
+    import modules.DBfi_19 as dbfi
+
+    fail = mock.Mock(side_effect=ConnectionError("secret-token-abc123"))
+    monkeypatch.setattr(dbfi.requests, "post", fail)
+    fake_warn = mock.Mock()
+    monkeypatch.setattr(dbfi.logger, "warning", fake_warn)
+
+    import asyncio
+    result = asyncio.run(dbfi.DBfi_enrich_and_persist_details(
+        [{"report_unique_key": "https://dbfi.test/key", "report_id": 1}],
+        db=mock.Mock(),
+    ))
+
+    assert isinstance(result, list)
+    assert fake_warn.called
+    call_msg = fake_warn.call_args[0][0]
+    assert "DBfi POST failed" in call_msg
+    assert "ConnectionError" in call_msg
+    assert "secret-token-abc123" not in call_msg


### PR DESCRIPTION
## Change
- preserve safe exception type and HTTP status when DBfi POST recovery fails
- never log exception strings, request URLs, or gate tokens
- preserve existing `None` fallback and recovery ordering

## Validation
- focused + existing DBfi tests: 11 passed
- py_compile, diff check, push hook: passed