### PR TITLE
refactor: expose KB report parse failures

### DIFF
--- a/scrapers/kb_core.py
+++ b/scrapers/kb_core.py
@@ -55,7 +55,8 @@ def scrape_kb(cfg: dict, from_date: str = None, to_date: str = None) -> list[dic
     for k in cfg["list_key"].split("."): jres = jres.get(k, [])
     items = jres if isinstance(jres, list) else []
     result = []
-    for item in items:
+    err_count = 0
+    for idx, item in enumerate(items):
         try:
             ik = cfg["item_keys"]; cat = item.get(ik["cat_id"], 0)
             board = cfg.get("category_map",{}).get(str(cat), 0)
@@ -70,6 +71,10 @@ def scrape_kb(cfg: dict, from_date: str = None, to_date: str = None) -> list[dic
                 writer=item.get(ik["writer"],""),telegram_url=dl,pdf_file_url=dl,
                 article_title=title,mkt_tp=mkt,report_unique_key=dl,
                 save_at=datetime.now(timezone(timedelta(hours=9))).isoformat()))
-        except Exception: continue
+        except Exception as exc:
+            err_count += 1
+            if err_count <= 5:
+                print(f"[kb] parse failed item[{idx}] ({type(exc).__name__})", file=sys.stderr)
+            continue
     print(f"[kb] {len(result)} articles collected", file=sys.stderr)
     return result

--- a/tests/test_kb_parse_error_context.py
+++ b/tests/test_kb_parse_error_context.py
@@ -1,0 +1,28 @@
+"""Verify KB parse failure logs index+type, not item data, and continues."""
+import sys
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def test_kb_parse_failure_logs_index_and_continues(capsys):
+    from scrapers.kb_core import scrape_kb
+
+    good = {"pCategoryid": 1, "documentid": "ok", "publicDate": "20260712",
+            "docTitle": "safe", "analystNm": "A"}
+    item2 = {"pCategoryid": 2, "documentid": "ok2", "publicDate": "20260712",
+             "docTitle": "also", "analystNm": "B"}
+    fake_resp = mock.Mock()
+    fake_resp.raise_for_status = mock.Mock()
+    fake_resp.json.return_value = {"response": {"reportList": [good, "bad_item", item2]}}
+
+    with mock.patch("scrapers.kb_core.requests.post", return_value=fake_resp):
+        result = scrape_kb({})
+
+    assert len(result) == 2
+    captured = capsys.readouterr()
+    assert "[kb] parse failed item[1]" in captured.err
+    assert "AttributeError" in captured.err
+    assert "bad_item" not in captured.err


### PR DESCRIPTION
## Change
- surface per-report KB parse failures with item index and exception type
- cap diagnostics at five entries per run
- preserve existing `continue`, result payload, and request behavior
- never log report payload values

## Validation
- focused test: 1 passed
- py_compile, diff check, push hook: passed