### PR TITLE
docs: clarify validation entrypoint roles

### DIFF
--- a/scrapers/validate.py
+++ b/scrapers/validate.py
@@ -1,4 +1,7 @@
-"""Scraper output validation — 모든 core 모듈이 리턴 전에 호출."""
+"""In-process validation library to normalize and validate scraped dict lists.
+Caller/Boundary: Scraper core modules (scrapers/*_core.py) processing in-memory dicts.
+Counterpart: For standalone CLI validation of JSON artifact files, use scripts/validate_scrape_result.py.
+"""
 import sys
 
 from models.report_payload import ReportPayload, ReportPayloadError

--- a/scripts/validate_scrape_result.py
+++ b/scripts/validate_scrape_result.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-"""Validate a GA artifact against its firm manifest policy before transfer."""
+"""Standalone CLI tool to validate a scraped JSON artifact against config/firms.yaml policies.
+Caller/Boundary: GA workflows or verify scripts reading a local JSON artifact path.
+Counterpart: For in-process result mapping and validation, use scrapers/validate.py instead.
+"""
 
 import argparse
 import json


### PR DESCRIPTION
## Change
- distinguish the standalone JSON artifact CLI from in-process scraper validation
- name each caller/input boundary and counterpart path
- no renames or behavior changes

## Validation
- py_compile: passed
- diff check and push hook: passed