### PR TITLE
fix: DB증권 텔레그램 링크 gate format(pv/gate?q=)으로 변경

### DIFF
--- a/models/SecReportsManager.py
+++ b/models/SecReportsManager.py
@@ -251,10 +251,7 @@ class SecReportsManager(LibrarySecReportsManager):
             firm_nm,report_date,
             article_title,pdf_url,writer,save_at,scraped_at,
             report_unique_key,
-            CASE
-                WHEN firm_id = 19 THEN pdf_url
-                ELSE telegram_url
-            END AS telegram_url
+            telegram_url
         FROM   {self.REPORTS_READ_VIEW}
         WHERE  save_at::date >= (%s::date - 2)
           AND  save_at::date <= %s
@@ -287,10 +284,7 @@ class SecReportsManager(LibrarySecReportsManager):
         """Fetch unsent keyword reports only after DBfi PDF URL is finalized."""
         sql = f"""
             SELECT r.report_id, r.firm_nm, r.article_title,
-                   CASE
-                       WHEN r.firm_id = 19 THEN r.pdf_url
-                       ELSE r.telegram_url
-                   END AS telegram_url,
+                   r.telegram_url,
                    r.save_at
             FROM {self.table_name} r
             LEFT JOIN tbl_report_send_history h

--- a/run/reset_send_status.py
+++ b/run/reset_send_status.py
@@ -38,7 +38,7 @@ async def reset_and_send(firm_order, date_str, board_order=None, do_send=False):
         SELECT report_id, firm_id, board_id, firm_nm, report_date,
                article_title, telegram_sent,
                writer, save_at,
-               CASE WHEN firm_id = 19 THEN pdf_url ELSE telegram_url END AS telegram_url,
+               telegram_url,
                report_unique_key
         FROM v_sec_reports_read
         WHERE firm_id = %s

--- a/run/reset_send_status.sh
+++ b/run/reset_send_status.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# ------------------------------------------------------------------
+# reset_send_status.sh — 도커 컨테이너 내에서 reset_send_status.py 실행
+#
+# 사용법:
+#   ./run/reset_send_status.sh --firm 19 --date 2026-07-13
+#   ./run/reset_send_status.sh --firm 19 --date 2026-07-13 --send
+#   ./run/reset_send_status.sh --firm 11 --date 2026-07-13 --board 3 --send
+#
+# Requirements:
+#   - 호스트에서 docker 명령어 사용 가능
+#   - ssh-reports-scraper-main-scraper-blue 또는 green 컨테이너 실행 중
+# ------------------------------------------------------------------
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# 실행 중인 scraper 컨테이너 찾기 (blue 우선)
+CONTAINER=""
+for candidate in ssh-reports-scraper-main-scraper-blue ssh-reports-scraper-main-scraper-green; do
+    if docker inspect "${candidate}" --format '{{.State.Running}}' 2>/dev/null | grep -q true; then
+        CONTAINER="${candidate}"
+        break
+    fi
+done
+
+if [ -z "${CONTAINER}" ]; then
+    echo "❌ 실행 중인 scraper 컨테이너를 찾을 수 없습니다." >&2
+    echo "   대상: ssh-reports-scraper-main-scraper-blue / green" >&2
+    exit 1
+fi
+
+echo "📦 대상 컨테이너: ${CONTAINER}"
+echo "🚀 실행: .venv/bin/python run/reset_send_status.py $*"
+echo ""
+
+docker exec -i "${CONTAINER}" .venv/bin/python run/reset_send_status.py "$@"

--- a/tests/test_scheduler_ga_broadcast.py
+++ b/tests/test_scheduler_ga_broadcast.py
@@ -188,5 +188,5 @@ def test_broadcast_ga_reports_filters_unresolved_dbfi(monkeypatch):
     assert len(sender.sent_messages) == 1
     assert "확정 DBFI" in sender.sent_messages[0]
     assert "미확정 DBFI" not in sender.sent_messages[0]
-    assert "https://dbfi.example.test/streamdocs/v4/documents/doc-id" in sender.sent_messages[0]
+    assert "https://dbfi.example.test/pv/gate?q=def" in sender.sent_messages[0]
     assert db.daily_update_calls[0][0][0]["report_id"] == 2

--- a/tests/test_sec_reports_manager.py
+++ b/tests/test_sec_reports_manager.py
@@ -205,7 +205,8 @@ def test_select_reports_ready_for_telegram_requires_dbfi_streamdocs_pdf(monkeypa
     assert "telegram_url LIKE 'https://dbfi.example.test/pv/gate%%'" in sql
     assert "pdf_url LIKE 'https://dbfi.example.test/streamdocs/v4/documents%%'" in sql
     assert "firm_nm NOT IN" not in sql
-    assert "WHEN firm_id = 19 THEN pdf_url" in sql
+    assert "telegram_url" in sql
+    assert "telegram_url LIKE 'https://dbfi.example.test/pv/gate%%'" in sql
 
 
 def test_keyword_fetch_requires_dbfi_streamdocs_pdf(monkeypatch):
@@ -230,7 +231,8 @@ def test_keyword_fetch_requires_dbfi_streamdocs_pdf(monkeypatch):
     assert "r.firm_id = 19" in sql
     assert "r.telegram_url LIKE 'https://dbfi.example.test/pv/gate%%'" in sql
     assert "r.pdf_url LIKE 'https://dbfi.example.test/streamdocs/v4/documents%%'" in sql
-    assert "WHEN r.firm_id = 19 THEN r.pdf_url" in sql
+    assert "r.telegram_url" in sql
+    assert "r.telegram_url LIKE 'https://dbfi.example.test/pv/gate%%'" in sql
 
 
 def test_dbfi_ready_condition_blocks_dbfi_when_prefix_missing(monkeypatch):

--- a/tests/test_telegram_send_audit.py
+++ b/tests/test_telegram_send_audit.py
@@ -196,7 +196,7 @@ class TestTelegramMessageChunks:
 
         assert "https://example.test/report%281%29.pdf" in chunks[0]["message"]
 
-    def test_chunks_use_dbfi_pdf_url_for_links(self):
+    def test_chunks_use_dbfi_telegram_url_for_links(self):
         from utils.telegram_message_builder import build_telegram_message_chunks
 
         rows = [
@@ -212,10 +212,10 @@ class TestTelegramMessageChunks:
 
         chunks = build_telegram_message_chunks(rows)
 
-        assert "streamdocs/v4/documents/new" in chunks[0]["message"]
-        assert "pv/gate" not in chunks[0]["message"]
+        assert "pv/gate?q=old" in chunks[0]["message"]
+        assert "streamdocs/v4/documents/new" not in chunks[0]["message"]
 
-    def test_chunks_use_dbfi_aliased_telegram_url_when_pdf_url_not_selected(self):
+    def test_chunks_use_dbfi_telegram_url_only_no_pdf_fallback(self):
         from utils.telegram_message_builder import build_telegram_message_chunks
 
         rows = [
@@ -224,14 +224,33 @@ class TestTelegramMessageChunks:
                 "firm_id": 19,
                 "firm_nm": "DB증권",
                 "article_title": "DBFI",
-                "telegram_url": "https://dbfi.example.test/streamdocs/v4/documents/new",
+                "telegram_url": "https://dbfi.example.test/pv/gate?q=valid",
             }
         ]
 
         chunks = build_telegram_message_chunks(rows)
 
-        assert "streamdocs/v4/documents/new" in chunks[0]["message"]
+        assert "pv/gate?q=valid" in chunks[0]["message"]
         assert "링크없음" not in chunks[0]["message"]
+
+    def test_chunks_dbfi_empty_telegram_url_shows_no_link(self):
+        from utils.telegram_message_builder import build_telegram_message_chunks
+
+        rows = [
+            {
+                "report_id": 19,
+                "firm_id": 19,
+                "firm_nm": "DB증권",
+                "article_title": "DBFI",
+                "telegram_url": "",
+                "pdf_file_url": "https://dbfi.example.test/streamdocs/v4/documents/ignored",
+            }
+        ]
+
+        chunks = build_telegram_message_chunks(rows)
+
+        assert "링크없음" in chunks[0]["message"]
+        assert "streamdocs" not in chunks[0]["message"]
 
 
 def test_daily_send_report_marks_only_successful_chunks(monkeypatch):

--- a/utils/telegram_message_builder.py
+++ b/utils/telegram_message_builder.py
@@ -5,7 +5,7 @@ def telegram_link_for_report(row):
     _pdf = row.get('pdf_file_url') or row.get('pdf_url')
     _src = row.get('source_url')
     if row.get('firm_id') == 19:
-        return _pdf or row.get('telegram_url') or ""
+        return row.get('telegram_url') or ""
     if row.get('firm_id') == 11:
         return row.get('telegram_url') if row.get('telegram_url') else "링크없음"
     return row.get('telegram_url') or _src or ""


### PR DESCRIPTION
## 변경 내용

DB증권(firm_id=19) 텔레그램 발송 링크를 `streamdocs/v4/documents/...` → `pv/gate?q=...` 형식으로 완전히 전환.

### 수정 파일

| 파일 | 변경 |
|------|------|
| `utils/telegram_message_builder.py` | DBfi: `telegram_url`만 사용, `pdf_file_url` fallback 제거 (비어있으면 "링크없음") |
| `models/SecReportsManager.py` | `select_reports_ready_for_telegram`, `fetch_keyword_reports` — `CASE WHEN firm_id=19 THEN pdf_url` 제거 |
| `run/reset_send_status.py` | 동일 CASE 제거 |
| `run/reset_send_status.sh` | docker exec 래퍼 스크립트 (신규) |
| `tests/*.py` | 테스트 assertion 업데이트 |

### 동작 방식
- `dbfi_ready_condition`이 `telegram_url LIKE 'gate_prefix%'` 조건으로 gate URL 없는 건은 발송 대상에서 자동 제외
- 후처리(`DBfi_enrich_and_persist_details` Pass 1)에서 `telegram_url`이 gate URL로 채워지면 발송 대상이 됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)