### PR TITLE
fix: harden report ingestion and LS PDF identity

### DIFF
--- a/docs/DEBUG_ENTRYPOINTS.md
+++ b/docs/DEBUG_ENTRYPOINTS.md
@@ -161,8 +161,38 @@ Relevant tests:
 uv run pytest tests/test_sec_reports_manager.py tests/test_db_factory.py tests/test_report_json_store.py -q
 ```
 
+### Investment-data coverage or LLM readiness
+
+Start with one compact live snapshot, not broad code search or a table dump:
+
+```bash
+bash scripts/ops_report_data_snapshot.sh --days 7
+```
+
+It is read-only and returns freshness, URL integrity, enrichment coverage,
+archive state, and stale firms as one JSON object. Add `--schema` only when a
+physical-column question remains. A populated scraper row does not prove that
+investment fields or LLM-ready source text exist.
+
 Do not reintroduce SQLite runtime paths. SQLite history lives on
 `archive/sqlite-legacy-20260705`.
+
+### Annual firm-day coverage and backfill candidates
+
+Export annual coverage before treating an absent report date as a scraper
+failure. `report_count` is based on the source publication date while
+`save_count` is based on the actual database write date; the distinction shows
+late imports and backfills.
+
+```bash
+bash scripts/ops_report_daily_stats.sh --year 2026 --summary
+bash scripts/ops_report_daily_stats.sh --year 2026 --daily > /tmp/sec-report-daily-2026.csv
+bash scripts/ops_report_daily_stats.sh --year 2026 --gaps
+```
+
+All modes are read-only. A long trailing `save_count` gap is an outage lead;
+confirm the workflow/runtime evidence and source board before writing a
+backfill.
 
 ### PostgreSQL Connection Exhaustion or Watchdog FATAL Storm
 

--- a/docs/INVESTMENT_DATA_PRODUCT.md
+++ b/docs/INVESTMENT_DATA_PRODUCT.md
@@ -1,0 +1,81 @@
+# `tbl_sec_reports` — 투자 데이터 제품 기준
+
+## 목적
+
+이 테이블은 단순 알림 로그가 아니라, 리서치 변화(종목·의견·목표가·근거)를
+비교하는 투자 의사결정 입력이어야 한다. live catalog가 스키마 권위이며 이 문서는
+DDL이 아닌 제품·운영 기준이다.
+
+## 먼저 볼 단일 입력
+
+```bash
+bash scripts/ops_report_data_snapshot.sh --days 7
+bash scripts/ops_report_daily_stats.sh --year 2026 --summary
+```
+
+첫 명령의 compact JSON만으로 freshness, URL 무결성, 투자 필드 커버리지와
+stale firm을 판단한다. 전체 테이블 덤프, 소스 탐색, 장문의 운영 문서를 LLM의
+첫 입력으로 사용하지 않는다. firm/day 원본은 장애 후보를 확인할 때만 연다.
+
+## 컬럼을 세 층으로 분리한다
+
+| 층 | 현재 컬럼 | 투자 판단에서의 역할 |
+|---|---|---|
+| 원천·식별 | `report_unique_key`, `firm_id`, `board_id`, `report_date`, `save_at`, `article_title`, `writer`, `pdf_url` | 중복 없는 시간축과 원문 증거 |
+| 구조화 신호 | `stock_tickers`, `stock_names`, `sector`, `report_type`, `rating`, `target_price`, `revision_type`, `fnguide_summary_id` | 종목별 컨센서스 변화·필터·랭킹 |
+| 근거·LLM | `article_text`, `gemini_summary`, `summary_model`, `summary_time`, `tags` | 투자 논리, 리스크, 촉매의 검증 가능한 요약 |
+
+`telegram_sent`, `sync_status`, `pdf_sync_status`, `retry_count`, `archive_path`,
+`gdrive_pdf_url`은 전달/아카이브 운영 상태다. 이를 투자 점수나 LLM 프롬프트의
+핵심 신호로 섞지 않는다.
+
+## 2026-07-13 live snapshot의 판단
+
+- 최근 7일 1,672건은 제목·PDF URL·Telegram URL 누락이 0건이다. 수집/전달은 정상이다.
+- 같은 기간 `article_text`와 LLM summary는 모두 0건, target price는 3건이다.
+- 전체 311,165건 중 ticker 3,302건, 본문 1,877건, LLM summary 321건뿐이다.
+
+따라서 현재 제품의 P0는 “더 많은 LLM 요약”이 아니라 **최신 리포트의 읽을 수 있는
+근거를 안정적으로 확보하는 것**이다. `article_text`는 PDF 전문의 중복 저장이 아니라
+증권사 사이트가 제공하는 HTML 요약/본문을 보존하는 용도다. 현재 PDF archive는 파일
+메타데이터만 갖고 추출 본문을 저장하지 않으므로, 이 필드를 제거하면 유일한 텍스트
+근거도 잃는다.
+
+## 우선순위
+
+1. **P0 — 최신 사이트 요약 확보와 실패 관측**: 사이트 HTML summary는 `article_text`에
+   보존하고, PDF 전문 추출은 별도 archive/text 저장소로 둔다. 둘을 한 컬럼에 섞지 않는다.
+   최근 7일 `article_text` 0건이면 해당 HTML-summary 수집 경로와 최신 PDF-text 추출 경로를
+   각각 점검한다.
+2. **P1 — 결정 필드의 fresh coverage**: 회사 리포트에 한해 ticker, rating, target price,
+   revision type을 추출하고 `source_span`/추출시각/모델을 함께 저장한다. 값만 저장하면
+   투자자가 근거를 확인할 수 없다.
+3. **P2 — 비교 가능한 LLM 산출물**: 원문+결정 필드가 있는 행만 요약한다. 출력은
+   `thesis`, `earnings_change`, `valuation_change`, `catalysts`, `risks`, `confidence`,
+   `evidence_spans`의 구조화 JSON이어야 하며, 자유문장 하나로는 스크리닝을 만들지 않는다.
+4. **P3 — UI/API**: 목록은 title/tag/목표가/의견/변경 방향만 전송한다. 원문과 evidence는
+   report-detail API에서 필요할 때만 가져온다. 목록 응답에 `article_text`를 넣지 않는다.
+
+## 펀드매니저용 최소 화면
+
+각 회사 리포트 카드에서 `종목 · 의견 · 목표가 · 직전 대비 · 핵심 변화 · 리스크 · 근거`
+를 한 화면에 보이고, `알 수 없음`을 빈값처럼 숨기지 않는다. 현재 데이터가 없는 경우
+그 사실을 표시해야 LLM 결과를 과신하지 않는다.
+
+## 다음 구현의 완료 기준
+
+- 최근 7일 회사 리포트의 `article_text` 커버리지와 extraction 실패율을 매일 snapshot에 표시
+- LLM summary는 원문·모델·추출시각·evidence를 가진 행만 생성
+- 프론트 normalizer가 이미 API가 반환하는 `stock_tickers`, `target_price`, `rating`,
+  `revision_type`, `report_type`를 버리지 않음
+- detail API는 원문을 on-demand로 제공하고 목록 API payload를 비대하게 만들지 않음
+
+## 현재 API/UI 경계 점검
+
+- backend `v_reports_api`와 `SecReportResponse`는 구조화 투자 필드를 목록 API에
+  제공한다. frontend `reportNormalizer`도 이를 보존해야 한다.
+- `article_text`와 `gdrive_pdf_url`은 물리 테이블에는 있지만 현재 API view/schema에는
+  없다. 목록 API에 추가하면 무한 스크롤과 LLM 입력 모두 불필요하게 비대해진다.
+- 다음 backend 변경은 `GET /external/api/reports/{report_id}/context`처럼 한 리포트만
+  반환하는 detail 경로여야 한다. 권한, 저작권 범위, 응답에서 허용할 원문 길이는 제품
+  결정이므로 이 문서만으로 public endpoint를 만들지 않는다.

--- a/docs/LLM_GUIDE.md
+++ b/docs/LLM_GUIDE.md
@@ -1,143 +1,32 @@
-# LLM Delegation Contract
+# LLM Runtime Guide
 
-Read `docs/DEBUG_ENTRYPOINTS.md` first. This file only defines the current
-DeepSeek/Gemini-AGY handoff contract. Runtime truth comes from code,
-`config/firms.yaml`, tests, current workflow runs, and live evidence.
+Start with [DEBUG_ENTRYPOINTS.md](DEBUG_ENTRYPOINTS.md). It selects the
+smallest source set for the active runtime path.
 
-## Roles
+## Delegation
 
-**DeepSeek** handles bounded implementation, workflow investigation, and test
-execution. **Gemini/AGY** handles documentation, inventories, and low-risk
-review. **Codex** reviews diffs, reruns validation on the integrated tree, and
-owns any `main` merge, push, deployment, or production write.
+The sole authority for LLM queue, dispatch, result files, and role boundaries
+is `/home/ubuntu/workspace/LLM_HARNESS_STANDARD.md`. Do not duplicate its task
+format or fixed-file contract here. In particular, do not commit `.agent_tasks/`
+and do not perform production DB writes, restarts, deploys, pushes, or main
+merges without the required approval.
 
-Every task must state allowed files, forbidden operations, exact validation,
-and an acceptance result. Delegates must not merge/push `main`, deploy, restart
-services, write production data, change secrets, or broaden scope unless the
-task explicitly authorizes it.
+## Runtime contracts
 
-## Fixed Files
+- `config/firms.yaml` is the firm manifest; `scraper_registry.py` validates it.
+- `models/report_payload.py` normalizes scraper rows; `report_unique_key` is
+  the idempotency key.
+- The scraper writes only its core delivery fields. Enrichment is a separate
+  pipeline, so an inserted row is not evidence that tags, company mapping,
+  price targets, article text, or an LLM summary exist.
+- `public.v_sec_reports_canonical` and `public.v_sec_reports_full` are the
+  preferred read surfaces. Live `pg_catalog` is authoritative for physical
+  schema; `sql/TB_SEC_REPORTS.sql` is a non-executable pointer.
+- Canonical physical fields: `report_unique_key`, `report_date`, `save_at`,
+  `telegram_sent`, and `pdf_url`. `article_url`/`source_url` are nullable
+  compatibility aliases, not a source-of-truth URL.
 
-Use only these gitignored files for direct dispatch:
-
-```text
-.agent_tasks/deepseek_next.json
-.agent_tasks/deepseek_result.json
-.agent_tasks/gemini_agy_next.json
-.agent_tasks/gemini_agy_result.json
-```
-
-Do not commit `.agent_tasks/` files. `scripts/llm_dispatch.sh` consumes the JSON
-paths above. The older `scripts/llm_task_queue.py` renders Markdown task files
-and is not compatible with direct dispatch; do not use it until the formats are
-aligned.
-
-## Compact Task Format
-
-```json
-{
-  "agt": "deepseek|gemini",
-  "ver": "YYYY-MM-DD HH:MM:SS KST",
-  "typ": "impl|investigate|audit|doc|review",
-  "goal": "one bounded result",
-  "ctx": "only evidence needed for this task",
-  "src": ["read-only/file"],
-  "mod": [{"f": "allowed/file", "do": "specific change"}],
-  "ban": ["op:main_merge", "op:push", "op:deploy", "op:db_write"],
-  "tst": ["exact validation command"],
-  "br": "branch-name",
-  "msg": "commit message",
-  "out": ".agent_tasks/<agent>_result.json"
-}
-```
-
-Keep one independently reviewable concern per task. Include the concrete error,
-workflow, firm, or DB query in `ctx`; do not paste broad history. Production
-evidence is read-only unless the user explicitly approves a write.
-
-## Compact Result Format
-
-```json
-{
-  "agt": "deepseek|gemini",
-  "ts": "YYYY-MM-DD HH:MM:SS KST",
-  "sum": "what changed or was learned",
-  "br": "branch-name",
-  "cm": "commit sha or empty",
-  "files": ["changed/file"],
-  "tst": [{"cmd": "exact command", "ok": true, "result": "count/output"}],
-  "blk": [{"what": "blocker"}],
-  "risk": "unverified behavior"
-}
-```
-
-`ok: true` means only that the named command passed. Use the evidence tiers in
-`docs/DEBUG_ENTRYPOINTS.md`; never translate local unit success into `built`,
-`deployed`, or `production verified`.
-
-## Dispatch
-
-Dry-run and inspect the target/prompt first:
-
-```bash
-bash scripts/llm_dispatch.sh deepseek
-bash scripts/llm_dispatch.sh gemini
-bash scripts/llm_dispatch.sh both --parallel
-```
-
-Send only after confirming each tmux target contains the intended LLM CLI:
-
-```bash
-bash scripts/llm_dispatch.sh deepseek --send --wait
-bash scripts/llm_dispatch.sh gemini --send --wait
-bash scripts/llm_dispatch.sh both --send --wait --parallel
-```
-
-After delegation, Codex must inspect the commit diff, check for unrelated dirty
-files, integrate onto the latest target tree, and rerun the required Tier 1
-commands. A delegate's source-branch result does not verify the merged commit.
-
-## Runtime Contracts
-
-### Firm routing
-
-`config/firms.yaml` is the firm manifest. `scraper_registry.py` loads and
-validates active entries. Do not maintain manual firm counts or lists in docs.
-For a firm failure, follow the file order in `docs/DEBUG_ENTRYPOINTS.md`.
-
-### Report payload
-
-`models/report_payload.py` and `scrapers/validate.py` own normalization.
-`scripts/validate_scrape_result.py` enforces the manifest `empty_policy` and
-firm identity. Do not introduce a firm-specific payload schema without a
-contract test.
-
-### Database fields
-
-Live `pg_catalog`/`information_schema` is authoritative for production. The
-canonical physical fields include:
-
-| Physical field | Dropped legacy name |
-|---|---|
-| `report_unique_key` | `key` |
-| `report_date` | `reg_dt` |
-| `save_at` | `save_time` |
-| `telegram_sent` | `main_ch_send_yn` |
-| `pdf_url` | `download_url` |
-
-`source_url` and `article_url` are nullable compatibility-view aliases; they do
-not map to `telegram_url`. `pdf_file_url`, `scraped_at`, `market_type`, and
-`firm_name` are view aliases, not physical insert fields.
-
-### Logs and operations
-
-Use `docs/OPS_LOG_TAIL.md` for current read-only log commands. Always include an
-exact time window. Treat repeated watchdog messages as symptoms until the first
-underlying service error is identified.
-
-## Stop Conditions
-
-Stop and return a blocker when the task requires an unlisted file, a secret is
-missing, the candidate tree contains unexplained changes, deterministic tests
-fail, or production mutation/restart/deploy would be required. Do not hide the
-condition with broad exception handling, weaker assertions, or skipped tests.
+For read-only production queries, follow
+`/home/ubuntu/workspace/lib/ssh_library/docs/USAGE.md` and use the
+`ssh_reports_hub` role. Include a bounded time window for logs and data-quality
+queries.

--- a/models/SecReportsManager.py
+++ b/models/SecReportsManager.py
@@ -116,7 +116,7 @@ class SecReportsManager(LibrarySecReportsManager):
             INSERT INTO {table_name} (
                 firm_id, board_id, firm_nm, report_date,
                 article_title, telegram_url, pdf_url,
-                writer, mkt_tp, report_unique_key, telegram_sent, save_at
+                writer, mkt_tp, report_unique_key, telegram_sent, save_at, article_text
             ) VALUES %s
             ON CONFLICT (report_unique_key) DO UPDATE SET
                 firm_id             = EXCLUDED.firm_id,
@@ -128,6 +128,7 @@ class SecReportsManager(LibrarySecReportsManager):
                 mkt_tp              = EXCLUDED.mkt_tp,
                 telegram_url        = COALESCE(NULLIF(EXCLUDED.telegram_url, ''), {table_name}.telegram_url),
                 pdf_url             = COALESCE(NULLIF(EXCLUDED.pdf_url, ''), {table_name}.pdf_url),
+                article_text        = COALESCE(NULLIF(EXCLUDED.article_text, ''), {table_name}.article_text),
                 telegram_sent       = COALESCE({table_name}.telegram_sent, false),
                 save_at             = {table_name}.save_at
             RETURNING report_unique_key, (xmax = 0) AS inserted

--- a/models/SecReportsManager.py
+++ b/models/SecReportsManager.py
@@ -195,6 +195,22 @@ class SecReportsManager(LibrarySecReportsManager):
                 )
         return {"status": "success"}
 
+    def save_article_text_if_empty(self, report_unique_key: str, article_text: str) -> int:
+        """Persist a one-shot site summary without replacing existing evidence."""
+        text = str(article_text or "").strip()
+        if not report_unique_key or not text:
+            return 0
+        result = self._execute(
+            f"""
+            UPDATE {self.table_name}
+            SET article_text = %s
+            WHERE report_unique_key = %s
+              AND COALESCE(btrim(article_text), '') = ''
+            """,
+            (text, report_unique_key),
+        )
+        return int(result.get("rowcount", 0)) if isinstance(result, dict) else 0
+
     async def update_telegram_url(
         self,
         record_id,

--- a/models/report_payload.py
+++ b/models/report_payload.py
@@ -26,6 +26,7 @@ class ReportPayload:
     mkt_tp: str
     report_unique_key: str
     save_at: datetime
+    article_text: str
 
     @classmethod
     def from_scraper(
@@ -71,6 +72,7 @@ class ReportPayload:
             mkt_tp=str(item.get("mkt_tp") or "KR"),
             report_unique_key=unique_key,
             save_at=save_at,
+            article_text=str(item.get("article_text") or "").strip(),
         )
 
     def to_scraper_dict(self, original: Mapping[str, Any]) -> dict[str, Any]:
@@ -99,6 +101,7 @@ class ReportPayload:
             self.report_unique_key,
             False,
             self.save_at,
+            self.article_text,
         )
 
 

--- a/modules/DS_11.py
+++ b/modules/DS_11.py
@@ -12,7 +12,6 @@ import sys
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from models.FirmInfo import FirmInfo
 from models.ConfigManager import config
-from scrapers.article_text import fetch_ds_summary
 
 
 def DS_checkNewArticle(full_scan=False):
@@ -64,7 +63,6 @@ def DS_checkNewArticle(full_scan=False):
 
                     title = title_element.get_text(strip=True)
                     source_url = title_element["href"]
-                    detail_url = requests.compat.urljoin(BASE_URL, source_url)
 
                     # wr_id 및 bo_table 추출을 위한 정규식
                     wr_id_match = re.search(r"wr_id=(\d+)", source_url)
@@ -104,11 +102,6 @@ def DS_checkNewArticle(full_scan=False):
                         "save_at": save_time,
                         "report_unique_key": pdf_url if pdf_url != "없음" else source_url
                     })
-                    # Broker-provided HTML summary is evidence, not PDF text.
-                    # A failed detail request must never fail the list scrape.
-                    article_text = fetch_ds_summary(detail_url)
-                    if article_text:
-                        json_data_list[-1]["article_text"] = article_text
 
                 # 한 페이지만 가져올 경우 루프 종료
                 if not full_scan:

--- a/modules/DS_11.py
+++ b/modules/DS_11.py
@@ -12,6 +12,7 @@ import sys
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from models.FirmInfo import FirmInfo
 from models.ConfigManager import config
+from scrapers.article_text import fetch_ds_summary
 
 
 def DS_checkNewArticle(full_scan=False):
@@ -63,6 +64,7 @@ def DS_checkNewArticle(full_scan=False):
 
                     title = title_element.get_text(strip=True)
                     source_url = title_element["href"]
+                    detail_url = requests.compat.urljoin(BASE_URL, source_url)
 
                     # wr_id 및 bo_table 추출을 위한 정규식
                     wr_id_match = re.search(r"wr_id=(\d+)", source_url)
@@ -102,6 +104,11 @@ def DS_checkNewArticle(full_scan=False):
                         "save_at": save_time,
                         "report_unique_key": pdf_url if pdf_url != "없음" else source_url
                     })
+                    # Broker-provided HTML summary is evidence, not PDF text.
+                    # A failed detail request must never fail the list scrape.
+                    article_text = fetch_ds_summary(detail_url)
+                    if article_text:
+                        json_data_list[-1]["article_text"] = article_text
 
                 # 한 페이지만 가져올 경우 루프 종료
                 if not full_scan:

--- a/modules/LS_0.py
+++ b/modules/LS_0.py
@@ -404,16 +404,15 @@ async def LS_detail(articles, firm_info=None, db=None):
             import random
             await asyncio.sleep(random.uniform(LS_DETAIL_DELAY_MIN, LS_DETAIL_DELAY_MAX))
 
-    # 목록의 report_date와 writer 이력으로 같은 날짜의 CDN URL만 먼저 찾는다.
-    # 날짜를 넓혀 존재하는 첫 PDF를 고르면 다른 게시물 PDF가 연결될 수 있으므로,
-    # 이 단계에서는 절대 날짜 이동 탐색을 허용하지 않는다. 못 찾은 건만 상세 페이지를
-    # 한 번 조회해 실제 첨부파일명을 읽는다.
+    # 목록의 report_date와 writer 이력으로 인접 3일 이내 CDN URL만 먼저 찾는다.
+    # 기존 백필용 광범위 탐색(±LS_SEARCH_DAYS)과 분리해 다른 게시물 PDF 오연결을
+    # 막고, 이 범위에서 못 찾은 건만 상세 페이지를 한 번 조회해 첨부파일명을 읽는다.
     detail_targets = []
     for article in articles:
         if str(article.get("telegram_url", "")).lower().endswith(".pdf"):
             continue
         inferred_url = await reconstruct_msg_url_from_db(
-            article, headers, exact_report_date=True
+            article, headers, date_window_days=3
         )
         if not inferred_url:
             detail_targets.append(article)
@@ -568,7 +567,7 @@ async def create_fallback_url(article, soup=None):
     
     return ""
 
-async def reconstruct_msg_url_from_db(article, headers, exact_report_date=False):
+async def reconstruct_msg_url_from_db(article, headers, date_window_days=None):
     """DB에 있는 성공한 msg URL 데이터를 기반으로 writer ID와 seq를 추론해서 msg URL 재구성.
 
     동일 작성자의 기존 성공 URL에서 writer_id(emp_id)와 seq 패턴을 추출하여
@@ -680,12 +679,12 @@ async def reconstruct_msg_url_from_db(article, headers, exact_report_date=False)
             return None
 
         candidates = []
-        # 목록 신규 수집에서는 목록의 report_date와 PDF 파일 날짜가 일치해야 한다.
-        # 그 외 보수/백필 경로만 기존의 날짜 이동 탐색을 사용한다.
-        day_offsets = [0] if exact_report_date else (
-            [0] + list(range(1, LS_SEARCH_DAYS + 1))
-            + list(range(-1, -LS_SEARCH_DAYS - 1, -1))
-        )
+        # 목록 신규 수집은 report_date 인접일만 허용한다. 당일, 이후/이전 순서로
+        # 가까운 후보부터 확인한다. date_window_days=None은 기존 백필의 넓은 범위다.
+        window = LS_SEARCH_DAYS if date_window_days is None else date_window_days
+        day_offsets = [0]
+        for offset in range(1, window + 1):
+            day_offsets.extend((offset, -offset))
         for day_offset in day_offsets:
             test_date = (base_date + timedelta(days=day_offset)).strftime("%Y%m%d")
             # seq: 예상값 기준 ±50, 최소 1

--- a/modules/LS_0.py
+++ b/modules/LS_0.py
@@ -359,15 +359,9 @@ async def process_article(session: ClientSession, article: dict, headers: dict, 
                         except Exception:
                             pass
 
-                # 2순위: DB 기반 writer ID 추론
-                if not resolved_url or not (resolved_url.startswith(LS_MSG_PREFIX) or
-                                            resolved_url.startswith(LS_NLS_PREFIX)):
-                    db_url = await reconstruct_msg_url_from_db(article, headers)
-                    if db_url:
-                        resolved_url = db_url
-                        logger.info(f"[LS][DB추론] msg URL 복구 성공: {db_url}")
-
-                # 3순위: upload/ fallback URL
+                # 목록 단계에서 report_date 기준 CDN 추정을 먼저 수행한다.
+                # 여기까지 왔다는 것은 그 추정이 실패한 경우이므로, 상세 페이지에 실제로
+                # 표시된 첨부파일명으로만 fallback URL을 만든다.
                 if not resolved_url:
                     resolved_url = await create_fallback_url(article, soup)
 
@@ -410,8 +404,38 @@ async def LS_detail(articles, firm_info=None, db=None):
             import random
             await asyncio.sleep(random.uniform(LS_DETAIL_DELAY_MIN, LS_DETAIL_DELAY_MAX))
 
+    # 목록의 report_date와 writer 이력으로 같은 날짜의 CDN URL만 먼저 찾는다.
+    # 날짜를 넓혀 존재하는 첫 PDF를 고르면 다른 게시물 PDF가 연결될 수 있으므로,
+    # 이 단계에서는 절대 날짜 이동 탐색을 허용하지 않는다. 못 찾은 건만 상세 페이지를
+    # 한 번 조회해 실제 첨부파일명을 읽는다.
+    detail_targets = []
+    for article in articles:
+        if str(article.get("telegram_url", "")).lower().endswith(".pdf"):
+            continue
+        inferred_url = await reconstruct_msg_url_from_db(
+            article, headers, exact_report_date=True
+        )
+        if not inferred_url:
+            detail_targets.append(article)
+            continue
+
+        article["source_url"] = inferred_url
+        article["telegram_url"] = inferred_url
+        article["pdf_file_url"] = inferred_url
+        logger.info(
+            "[LS][목록추론] report_date={} PDF 복구: {}",
+            _article_report_date(article), inferred_url,
+        )
+        if db and article.get("report_id"):
+            await db.update_telegram_url(
+                record_id=article["report_id"],
+                telegram_url=inferred_url,
+                article_title=article.get("article_title"),
+                pdf_file_url=inferred_url,
+            )
+
     async with aiohttp.ClientSession() as session:
-        tasks = [sem_process_article(session, article) for article in articles]
+        tasks = [sem_process_article(session, article) for article in detail_targets]
         await asyncio.gather(*tasks)
 
     return articles
@@ -544,7 +568,7 @@ async def create_fallback_url(article, soup=None):
     
     return ""
 
-async def reconstruct_msg_url_from_db(article, headers):
+async def reconstruct_msg_url_from_db(article, headers, exact_report_date=False):
     """DB에 있는 성공한 msg URL 데이터를 기반으로 writer ID와 seq를 추론해서 msg URL 재구성.
 
     동일 작성자의 기존 성공 URL에서 writer_id(emp_id)와 seq 패턴을 추출하여
@@ -656,8 +680,12 @@ async def reconstruct_msg_url_from_db(article, headers):
             return None
 
         candidates = []
-        # 날짜: 당일 → 미래 → 과거 순서로 탐색 (보고서는 게시일 이후 업로드가 일반적)
-        day_offsets = [0] + list(range(1, LS_SEARCH_DAYS + 1)) + list(range(-1, -LS_SEARCH_DAYS - 1, -1))
+        # 목록 신규 수집에서는 목록의 report_date와 PDF 파일 날짜가 일치해야 한다.
+        # 그 외 보수/백필 경로만 기존의 날짜 이동 탐색을 사용한다.
+        day_offsets = [0] if exact_report_date else (
+            [0] + list(range(1, LS_SEARCH_DAYS + 1))
+            + list(range(-1, -LS_SEARCH_DAYS - 1, -1))
+        )
         for day_offset in day_offsets:
             test_date = (base_date + timedelta(days=day_offset)).strftime("%Y%m%d")
             # seq: 예상값 기준 ±50, 최소 1

--- a/scraper.py
+++ b/scraper.py
@@ -312,8 +312,18 @@ def dedupe_reports_by_unique_key(scraped_reports):
 
 
 async def insert_scraped_reports(db, reports, label="DB"):
-    inserted, updated = db.insert_json_data_list(list(reports))
+    report_list = list(reports)
+    inserted, updated = db.insert_json_data_list(report_list)
     logger.success(f"[{label}] DB Sync: {inserted} new, {updated} updated.")
+    new_keys = set(getattr(db, "_last_inserted_keys", []) or [])
+    if new_keys:
+        from scrapers.article_text import fetch_new_site_summaries
+
+        summaries = await asyncio.to_thread(fetch_new_site_summaries, report_list, new_keys)
+        for key, article_text in summaries.items():
+            db.save_article_text_if_empty(key, article_text)
+        if summaries:
+            logger.info(f"[{label}] one-shot detail summaries saved={len(summaries)}")
     await asyncio.sleep(1)
     return inserted, updated
 

--- a/scrapers/article_text.py
+++ b/scrapers/article_text.py
@@ -11,6 +11,7 @@ import re
 from html import unescape
 
 import requests
+from urllib.parse import urljoin
 
 
 def extract_ds_summary(html: str, *, max_chars: int = 10_000) -> str:
@@ -40,3 +41,23 @@ def fetch_ds_summary(url: str, *, timeout: int = 10) -> str:
         return extract_ds_summary(response.text)
     except requests.RequestException:
         return ""
+
+
+def fetch_new_site_summaries(reports: list[dict], new_keys: set[str]) -> dict[str, str]:
+    """Fetch at most one detail page for each newly inserted supported report.
+
+    List scraping must never call this for historical/existing rows. Failed
+    detail pages are intentionally returned as absent rather than retried here;
+    retries belong to an explicit operator job, not the every-run scraper.
+    """
+    extracted: dict[str, str] = {}
+    for report in reports:
+        key = str(report.get("report_unique_key") or "")
+        if key not in new_keys or report.get("article_text"):
+            continue
+        if report.get("firm_id") == 11:  # DS: list source_url is a relative detail link.
+            detail_url = urljoin("https://www.ds-sec.co.kr/", str(report.get("source_url") or ""))
+            text = fetch_ds_summary(detail_url)
+            if text:
+                extracted[key] = text
+    return extracted

--- a/scrapers/article_text.py
+++ b/scrapers/article_text.py
@@ -1,0 +1,42 @@
+"""Bounded extraction of broker-provided HTML summaries.
+
+This module deliberately handles HTML summaries only. PDF full-text extraction
+belongs to the archive pipeline and must not be silently mixed into
+``tbl_sec_reports.article_text``.
+"""
+
+from __future__ import annotations
+
+import re
+from html import unescape
+
+import requests
+
+
+def extract_ds_summary(html: str, *, max_chars: int = 10_000) -> str:
+    """Return DS's report-body summary or an empty string when absent."""
+    match = re.search(
+        r'<(?:div|section)[^>]+id=["\']bo_v_con["\'][^>]*>(.*?)</(?:div|section)>',
+        html,
+        re.IGNORECASE | re.DOTALL,
+    )
+    if not match:
+        return ""
+    text = re.sub(r"<[^>]+>", " ", match.group(1))
+    text = re.sub(r"\s+", " ", unescape(text)).strip()
+    return text[:max_chars] if len(text) > 30 else ""
+
+
+def fetch_ds_summary(url: str, *, timeout: int = 10) -> str:
+    """Fetch one DS detail page; source failures are represented by empty text."""
+    try:
+        response = requests.get(
+            url,
+            headers={"User-Agent": "Mozilla/5.0"},
+            verify=False,
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        return extract_ds_summary(response.text)
+    except requests.RequestException:
+        return ""

--- a/scrapers/hmsec_core.py
+++ b/scrapers/hmsec_core.py
@@ -2,20 +2,24 @@ import sys
 """Hyundai Motor Securities — config 기반."""
 import time, requests
 from datetime import datetime, timezone, timedelta
+from scrapers.legacy_url_config import normalize_legacy_url_config
 
 def scrape_hmsec(cfg: dict) -> list[dict]:
-    if isinstance(cfg, list): cfg = {"urls": cfg}
-    elif isinstance(cfg, str): cfg = {"url": cfg}
+    cfg = normalize_legacy_url_config(cfg, firm_key="Hmsec")
     requests.packages.urllib3.disable_warnings()
     result = []
+    parse_errors = 0
     for board_order, url in enumerate(cfg.get("urls", [cfg.get("url","")])):
         if not url: continue
         page, total_pages, max_p = 1, None, cfg.get("max_pages", 5)
         while page <= max_p:
             try:
                 jres = requests.get(url, params={"curPage": page}, headers=cfg["headers"], timeout=30, verify=False).json()
-            except Exception: break
+            except Exception as exc:
+                print(f"[hmsec] request failed board={board_order} page={page} {type(exc).__name__}: {exc}", file=sys.stderr)
+                break
             items = jres.get(cfg["list_key"], [])
+            print(f"[hmsec] board={board_order} page={page} api_items={len(items)}", file=sys.stderr)
             if not items: break
             if total_pages is None: total_pages = jres.get(cfg["paging_key"], {}).get("totalPages", 1)
             for item in items:
@@ -28,9 +32,14 @@ def scrape_hmsec(cfg: dict) -> list[dict]:
                         writer=(item.get(ik["writer"],"")).strip(),source_url=vu,pdf_file_url=dl,
                         telegram_url=vu,report_unique_key=vu,
                         save_at=datetime.now(timezone(timedelta(hours=9))).isoformat()))
-                except Exception: continue
+                except Exception as exc:
+                    parse_errors += 1
+                    if parse_errors == 1:
+                        print(f"[hmsec] parse failed board={board_order} page={page} {type(exc).__name__}: {exc}", file=sys.stderr)
             page += 1
             if total_pages and page > total_pages: break
             time.sleep(0.3)
+    if parse_errors:
+        print(f"[hmsec] skipped malformed rows={parse_errors}", file=sys.stderr)
     print(f"[hmsec] {len(result)} articles collected", file=sys.stderr)
     return result

--- a/scrapers/hmsec_core.py
+++ b/scrapers/hmsec_core.py
@@ -30,6 +30,7 @@ def scrape_hmsec(cfg: dict) -> list[dict]:
                     result.append(dict(firm_id=9,board_id=board_order,firm_nm="현대차증권",
                         report_date=(item.get(ik["report_date"],"")).strip(),article_title=item[ik["title"]],
                         writer=(item.get(ik["writer"],"")).strip(),source_url=vu,pdf_file_url=dl,
+                        article_text=str(item.get("CONTENTS") or "").strip(),
                         telegram_url=vu,report_unique_key=vu,
                         save_at=datetime.now(timezone(timedelta(hours=9))).isoformat()))
                 except Exception as exc:

--- a/scrapers/kiwoom_core.py
+++ b/scrapers/kiwoom_core.py
@@ -2,16 +2,17 @@ import sys
 """Kiwoom Securities — config 기반."""
 import re, requests
 from datetime import datetime, timezone, timedelta
+from scrapers.legacy_url_config import normalize_legacy_url_config
 
 def scrape_kiwoom(cfg: dict) -> list[dict]:
-    if isinstance(cfg, list): cfg = {"urls": cfg}
-    elif isinstance(cfg, str): cfg = {"url": cfg}
+    cfg = normalize_legacy_url_config(cfg, firm_key="Kiwoom")
     requests.packages.urllib3.disable_warnings()
     now = datetime.now(timezone(timedelta(hours=9)))
     p = dict(cfg["payload"])
     p["stdate"] = p.get("stdate","{year}0101").replace("{year}0101",f"{now.year}0101")
     p["eddate"] = p.get("eddate","{today}").replace("{today}",now.strftime("%Y%m%d"))
     result = []
+    parse_errors = 0
     for board_order, url in enumerate(cfg.get("urls", [cfg.get("url","")])):
         if not url: continue
         h = dict(cfg["headers"]); h["Referrer"] = url
@@ -19,7 +20,10 @@ def scrape_kiwoom(cfg: dict) -> list[dict]:
             resp = requests.post(url, headers=h, data=p, verify=False, timeout=30)
             resp.raise_for_status()
             items = resp.json().get(cfg["list_key"], [])
-        except Exception: continue
+        except Exception as exc:
+            print(f"[kiwoom] request failed board={board_order} {type(exc).__name__}: {exc}", file=sys.stderr)
+            continue
+        print(f"[kiwoom] board={board_order} api_items={len(items)}", file=sys.stderr)
         for item in items:
             try:
                 ik = cfg["item_keys"]
@@ -28,6 +32,11 @@ def scrape_kiwoom(cfg: dict) -> list[dict]:
                     report_date=re.sub(r"[-./]","",item[ik["report_date"]]),article_title=item[ik["title"]],
                     writer=item.get(ik["writer"],""),telegram_url=dl,pdf_file_url=dl,report_unique_key=dl,
                     save_at=datetime.now(timezone(timedelta(hours=9))).isoformat()))
-            except Exception: continue
+            except Exception as exc:
+                parse_errors += 1
+                if parse_errors == 1:
+                    print(f"[kiwoom] parse failed board={board_order} {type(exc).__name__}: {exc}", file=sys.stderr)
+    if parse_errors:
+        print(f"[kiwoom] skipped malformed rows={parse_errors}", file=sys.stderr)
     print(f"[kiwoom] {len(result)} articles collected", file=sys.stderr)
     return result

--- a/scrapers/legacy_url_config.py
+++ b/scrapers/legacy_url_config.py
@@ -1,0 +1,118 @@
+"""Normalize legacy URL-list secrets into the current core-parser contract.
+
+The production secret store intentionally keeps public source URLs only.  The
+parser-specific selectors and request payloads belong in versioned code, not
+in an opaque secret.  A full config dict may still override these defaults for
+an emergency source change.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from scrapers.config_guard import ScraperConfigError, normalize_cfg
+
+
+_BROWSER_HEADERS = {"User-Agent": "Mozilla/5.0"}
+
+FIRM_DEFAULTS: dict[str, dict[str, Any]] = {
+    "Samsung": {
+        "headers": _BROWSER_HEADERS,
+        "item_sel": "#content > section.bbsLstWrap > ul > li",
+        "title_sel": "dt > strong",
+        "author_sel": "dd > span",
+        "author_idx": 2,
+        "url_tpl": (
+            "https://www.samsungpop.com/common.do?cmd=down&saveKey=research.pdf"
+            "&fileName={path}&contentType=application/pdf&inlineYn=Y"
+        ),
+        "firm_id": 5,
+        "firm_nm": "삼성증권",
+    },
+    "Miraeasset": {
+        "row_sel": "tbody tr",
+        "skip_rows": 2,
+        "cell_report_date": 1,
+        "cell_title": 2,
+        "cell_writer": 4,
+        "attach_sel": ".bbsList_layer_icon a",
+        "attach_pattern": r"javascript:downConfirm\('(.*?)'",
+        "firm_id": 8,
+        "firm_nm": "미래에셋증권",
+    },
+    "Hmsec": {
+        "headers": _BROWSER_HEADERS,
+        "list_key": "data_list",
+        "paging_key": "paging",
+        "item_keys": {
+            "file": "UPLOAD_FILE1",
+            "report_date": "REG_DATE",
+            "title": "SUBJECT",
+            "writer": "NAME",
+        },
+        "url_tpl": "https://www.hmsec.com/documents/research/{file}",
+        "viewer_tpl": (
+            "https://docs.hmsec.com/SynapDocViewServer/job?fid={url}"
+            "&sync=true&fileType=URL&filePath={url}"
+        ),
+    },
+    "Kiwoom": {
+        "headers": _BROWSER_HEADERS,
+        "payload": {
+            "pageNo": 1,
+            "pageSize": 100,
+            "stdate": "{year}0101",
+            "eddate": "{today}",
+            "f_keyField": "",
+            "f_key": "",
+            "_reqAgent": "ajax",
+            "dummyVal": 0,
+        },
+        "list_key": "researchList",
+        "item_keys": {
+            "menu_gb": "rMenuGb",
+            "atta_file": "attaFile",
+            "report_date": "makeDt",
+            "title": "titl",
+            "writer": "workId",
+        },
+        "url_tpl": (
+            "https://bbn.kiwoom.com/research/SPdfFileView?rMenuGb={menu_gb}"
+            "&attaFile={atta_file}&makeDt={report_date}"
+        ),
+    },
+    "Toss": {
+        "headers": _BROWSER_HEADERS,
+        "item_keys": {
+            "title": "title",
+            "report_date": "createdAt",
+            "writer": "writer",
+            "files": "files",
+            "contents": "contents",
+            "category": "category",
+        },
+        "global_keyword": "global",
+    },
+}
+
+
+def normalize_legacy_url_config(cfg: Any, *, firm_key: str) -> dict[str, Any]:
+    """Return a full parser config while preserving explicit config overrides."""
+    if firm_key not in FIRM_DEFAULTS:
+        raise ScraperConfigError(f"unknown legacy URL-list firm: {firm_key}")
+
+    supplied = normalize_cfg(cfg, firm_key=firm_key)
+    if "url" in supplied and "urls" not in supplied:
+        supplied = {**supplied, "urls": [supplied["url"]]}
+
+    merged = deepcopy(FIRM_DEFAULTS[firm_key])
+    for key, value in supplied.items():
+        if key in {"headers", "item_keys", "payload"} and isinstance(value, dict):
+            merged[key] = {**merged.get(key, {}), **value}
+        else:
+            merged[key] = value
+
+    if not merged.get("urls"):
+        raise ScraperConfigError(f"{firm_key}: no source URLs configured")
+    return merged

--- a/scrapers/miraeasset_core.py
+++ b/scrapers/miraeasset_core.py
@@ -3,20 +3,24 @@ import sys
 import re, requests
 from datetime import datetime, timezone, timedelta
 from bs4 import BeautifulSoup
+from scrapers.legacy_url_config import normalize_legacy_url_config
 
 def scrape_miraeasset(cfg: dict) -> list[dict]:
-    if isinstance(cfg, list): cfg = {"urls": cfg}
-    elif isinstance(cfg, str): cfg = {"url": cfg}
+    cfg = normalize_legacy_url_config(cfg, firm_key="Miraeasset")
     requests.packages.urllib3.disable_warnings()
     result = []
+    parse_errors = 0
     for idx, url in enumerate(cfg.get("urls",[cfg.get("url","")])):
         if not url: continue
         try:
             resp = requests.get(url, timeout=30, verify=False)
             resp.raise_for_status()
-        except Exception: continue
+        except Exception as exc:
+            print(f"[miraeasset] request failed board={idx} {type(exc).__name__}: {exc}", file=sys.stderr)
+            continue
         soup = BeautifulSoup(resp.text, "html.parser")
         rows = soup.select(cfg["row_sel"])[cfg.get("skip_rows",0):]
+        print(f"[miraeasset] board={idx} selector_matches={len(rows)}", file=sys.stderr)
         for row in rows:
             try:
                 rdt = re.sub(r"[-./]","",row.select_one(f"td:nth-child({cfg['cell_report_date']})").get_text(strip=True))
@@ -30,6 +34,11 @@ def scrape_miraeasset(cfg: dict) -> list[dict]:
                 result.append(dict(firm_id=cfg["firm_id"],board_id=idx,
                     firm_nm=cfg["firm_nm"],report_date=rdt,writer=writer,telegram_url=dl,
                     article_title=title,save_at=datetime.now(timezone(timedelta(hours=9))).isoformat(),report_unique_key=dl))
-            except Exception: continue
+            except Exception as exc:
+                parse_errors += 1
+                if parse_errors == 1:
+                    print(f"[miraeasset] parse failed board={idx} {type(exc).__name__}: {exc}", file=sys.stderr)
+    if parse_errors:
+        print(f"[miraeasset] skipped malformed rows={parse_errors}", file=sys.stderr)
     print(f"[miraeasset] {len(result)} articles collected", file=sys.stderr)
     return result

--- a/scrapers/samsung_core.py
+++ b/scrapers/samsung_core.py
@@ -3,20 +3,25 @@ import sys
 import re, requests
 from datetime import datetime, timezone, timedelta
 from bs4 import BeautifulSoup
+from scrapers.legacy_url_config import normalize_legacy_url_config
 
 def scrape_samsung(cfg: dict) -> list[dict]:
-    if isinstance(cfg, list): cfg = {"urls": cfg}
-    elif isinstance(cfg, str): cfg = {"url": cfg}
+    cfg = normalize_legacy_url_config(cfg, firm_key="Samsung")
     requests.packages.urllib3.disable_warnings()
     result = []
+    parse_errors = 0
     for board_order, url in enumerate(cfg.get("urls",[cfg.get("url","")])):
         if not url: continue
         try:
             resp = requests.get(url, headers=cfg["headers"], verify=False, timeout=30)
             resp.raise_for_status()
-        except Exception: continue
+        except Exception as exc:
+            print(f"[samsung] request failed board={board_order} {type(exc).__name__}: {exc}", file=sys.stderr)
+            continue
         soup = BeautifulSoup(resp.text, "html.parser")
-        for item in soup.select(cfg["item_sel"]):
+        items = soup.select(cfg["item_sel"])
+        print(f"[samsung] board={board_order} selector_matches={len(items)}", file=sys.stderr)
+        for item in items:
             try:
                 t_el = item.select_one(cfg["title_sel"])
                 if not t_el: continue
@@ -34,6 +39,11 @@ def scrape_samsung(cfg: dict) -> list[dict]:
                     firm_nm=cfg["firm_nm"],report_date=report_date,telegram_url=dl,
                     article_title=title,writer=author,report_unique_key=dl,
                     save_at=datetime.now(timezone(timedelta(hours=9))).isoformat()))
-            except Exception: continue
+            except Exception as exc:
+                parse_errors += 1
+                if parse_errors == 1:
+                    print(f"[samsung] parse failed board={board_order} {type(exc).__name__}: {exc}", file=sys.stderr)
+    if parse_errors:
+        print(f"[samsung] skipped malformed rows={parse_errors}", file=sys.stderr)
     print(f"[samsung] {len(result)} articles collected", file=sys.stderr)
     return result

--- a/scrapers/shinhan_core.py
+++ b/scrapers/shinhan_core.py
@@ -59,9 +59,15 @@ def scrape_shinhan(cfg: dict) -> list[dict]:
                 dl = canonical_shinhan_url(item.get("attachment_url") or "")
                 if not dl.startswith("http"): continue
                 board = BOARD_MAP.get(bbs_name, 99)
+                # The list API already exposes the text shown by the mobile
+                # detail view. Persist it as broker-provided evidence instead
+                # of paying for a second request per report.
+                article_text = str(item.get("summary") or "").strip()
                 result.append({"firm_id":1,"board_id":board,
                     "firm_nm":"신한증권","report_date":report_date,"telegram_url":dl,
                     "article_title":item.get("title","").strip(),"writer":item.get("nickname","").strip(),
+                    "source_url":str(item.get("message_url") or "").strip(),
+                    "article_text":article_text,
                     "report_unique_key":dl,
                     "save_at":datetime.now(timezone(timedelta(hours=9))).isoformat()})
             next_key = jres.get("header",{}).get("repeatKeyN","")

--- a/scrapers/shinyoung_core.py
+++ b/scrapers/shinyoung_core.py
@@ -81,6 +81,7 @@ def scrape_shinyoung(cfg: dict) -> list[dict]:
                 "report_date": re.sub(r"[-./]", "", item[item_keys["report_date"]]),
                 "writer": item.get(item_keys["writer"], ""),
                 "article_title": title, "telegram_url": dl, 
+                "article_text": str(item.get("SUMMARY") or "").strip(),
                 "report_unique_key": dl,
                 "save_at": datetime.now(timezone(timedelta(hours=9))).isoformat(),
             })

--- a/scrapers/toss_core.py
+++ b/scrapers/toss_core.py
@@ -2,12 +2,13 @@ import sys
 """TOSS Securities — config 기반."""
 import re, requests
 from datetime import datetime, timezone, timedelta
+from scrapers.legacy_url_config import normalize_legacy_url_config
 
 def scrape_toss(cfg: dict) -> list[dict]:
-    if isinstance(cfg, list): cfg = {"urls": cfg}
-    elif isinstance(cfg, str): cfg = {"url": cfg}
+    cfg = normalize_legacy_url_config(cfg, firm_key="Toss")
     requests.packages.urllib3.disable_warnings()
     result = []
+    parse_errors = 0
     for board_order, base_url in enumerate(cfg.get("urls", [cfg.get("url","")])):
         if not base_url: continue
         page, total_pages = 0, None
@@ -21,6 +22,7 @@ def scrape_toss(cfg: dict) -> list[dict]:
                 print(f"[toss] request failed page={page} {type(exc).__name__}: {exc}", file=sys.stderr)
                 break
             items = jres.get("result", {}).get("list", [])
+            print(f"[toss] board={board_order} page={page} api_items={len(items)}", file=sys.stderr)
             if not items: break
             if total_pages is None: total_pages = jres.get("result", {}).get("pagingParam", {}).get("totalPageCount", 1)
             for item in items:
@@ -41,8 +43,13 @@ def scrape_toss(cfg: dict) -> list[dict]:
                         report_date=re.sub(r"[-./]","",report_date),telegram_url=dl,
                         article_title=title,writer=writer,mkt_tp=mkt,report_unique_key=dl,
                         save_at=datetime.now(timezone(timedelta(hours=9))).isoformat()))
-                except Exception: continue
+                except Exception as exc:
+                    parse_errors += 1
+                    if parse_errors == 1:
+                        print(f"[toss] parse failed board={board_order} page={page} {type(exc).__name__}: {exc}", file=sys.stderr)
             page += 1
             if total_pages and page >= total_pages: break
+    if parse_errors:
+        print(f"[toss] skipped malformed rows={parse_errors}", file=sys.stderr)
     print(f"[toss] {len(result)} articles collected", file=sys.stderr)
     return result

--- a/scripts/ops_report_daily_stats.sh
+++ b/scripts/ops_report_daily_stats.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Read-only yearly firm/day coverage for tbl_sec_reports.
+set -euo pipefail
+
+year=$(date +%Y)
+mode=summary
+
+usage() {
+  cat <<'EOF'
+Usage: bash scripts/ops_report_daily_stats.sh [--year YYYY] [--summary|--daily|--gaps]
+
+Read-only OCI export for tbl_sec_reports (Asia/Seoul dates, business days only).
+  --summary  one row per firm: annual counts and report/save trailing gaps (default)
+  --daily    one row per firm x business day; report_count is keyed by report_date,
+             save_count by save_at, so delayed imports/backfills remain visible
+  --gaps     only business-day rows with no report; use with --daily data before
+             declaring a scraper outage, because a source may not publish daily
+EOF
+}
+
+while (($#)); do
+  case "$1" in
+    --year)
+      [[ ${2:-} =~ ^20[0-9]{2}$ ]] || { echo "--year must be YYYY" >&2; exit 2; }
+      year=$2; shift 2 ;;
+    --summary) mode=summary; shift ;;
+    --daily) mode=daily; shift ;;
+    --gaps) mode=gaps; shift ;;
+    --help|-h) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+end_date="${year}-12-31"
+if [[ $year == "$(date +%Y)" ]]; then end_date=$(date +%F); fi
+
+case "$mode" in
+  summary)
+    query="
+WITH params AS (SELECT date '${year}-01-01' AS start_day, date '${end_date}' AS end_day),
+firms AS (
+  SELECT firm_id, max(firm_nm) AS firm_nm FROM public.tbl_sec_reports
+  WHERE firm_id IS NOT NULL GROUP BY firm_id
+), report_counts AS (
+  SELECT firm_id, report_date::date AS day, count(*) AS count
+  FROM public.tbl_sec_reports, params
+  WHERE report_date BETWEEN params.start_day AND params.end_day
+  GROUP BY firm_id, report_date::date
+), save_counts AS (
+  SELECT firm_id, (save_at AT TIME ZONE 'Asia/Seoul')::date AS day, count(*) AS count
+  FROM public.tbl_sec_reports, params
+  WHERE save_at >= params.start_day AND save_at < params.end_day + interval '1 day'
+  GROUP BY firm_id, (save_at AT TIME ZONE 'Asia/Seoul')::date
+), daily AS (
+  SELECT f.firm_id, f.firm_nm, d::date AS day,
+    coalesce(rc.count, 0) AS report_count, coalesce(sc.count, 0) AS save_count
+  FROM firms f CROSS JOIN params p
+  CROSS JOIN LATERAL generate_series(p.start_day, p.end_day, interval '1 day') d
+  LEFT JOIN report_counts rc ON rc.firm_id = f.firm_id AND rc.day = d::date
+  LEFT JOIN save_counts sc ON sc.firm_id = f.firm_id AND sc.day = d::date
+  WHERE extract(isodow FROM d) BETWEEN 1 AND 5
+), aggregate AS (
+  SELECT firm_id, max(firm_nm) AS firm_nm, count(*) AS business_days,
+    sum(report_count) AS reports, sum(save_count) AS saved_rows,
+    max(day) FILTER (WHERE report_count > 0) AS last_report_day,
+    max(day) FILTER (WHERE save_count > 0) AS last_save_day,
+    count(*) FILTER (WHERE report_count = 0) AS no_report_days,
+    count(*) FILTER (WHERE save_count = 0) AS no_save_days
+  FROM daily GROUP BY firm_id
+)
+SELECT firm_id, firm_nm, business_days, reports, saved_rows, last_report_day, last_save_day,
+  (SELECT count(*) FROM daily x WHERE x.firm_id = a.firm_id AND x.day > a.last_report_day) AS trailing_report_gap_business_days,
+  (SELECT count(*) FROM daily x WHERE x.firm_id = a.firm_id AND x.day > a.last_save_day) AS trailing_save_gap_business_days,
+  no_report_days, no_save_days
+FROM aggregate a ORDER BY trailing_save_gap_business_days DESC NULLS LAST, firm_id;"
+    ;;
+  daily|gaps)
+    where=""
+    [[ $mode == gaps ]] && where="AND coalesce(rc.count, 0) = 0"
+    query="
+WITH params AS (SELECT date '${year}-01-01' AS start_day, date '${end_date}' AS end_day),
+firms AS (SELECT firm_id, max(firm_nm) AS firm_nm FROM public.tbl_sec_reports WHERE firm_id IS NOT NULL GROUP BY firm_id),
+report_counts AS (
+  SELECT firm_id, report_date::date AS day, count(*) AS count
+  FROM public.tbl_sec_reports, params WHERE report_date BETWEEN params.start_day AND params.end_day
+  GROUP BY firm_id, report_date::date
+), save_counts AS (
+  SELECT firm_id, (save_at AT TIME ZONE 'Asia/Seoul')::date AS day, count(*) AS count,
+    max(save_at AT TIME ZONE 'Asia/Seoul') AS latest_saved_at
+  FROM public.tbl_sec_reports, params
+  WHERE save_at >= params.start_day AND save_at < params.end_day + interval '1 day'
+  GROUP BY firm_id, (save_at AT TIME ZONE 'Asia/Seoul')::date
+)
+SELECT f.firm_id, f.firm_nm, d::date AS business_day,
+  coalesce(rc.count, 0) AS report_count, coalesce(sc.count, 0) AS save_count, sc.latest_saved_at
+FROM firms f CROSS JOIN params p
+CROSS JOIN LATERAL generate_series(p.start_day, p.end_day, interval '1 day') d
+LEFT JOIN report_counts rc ON rc.firm_id = f.firm_id AND rc.day = d::date
+LEFT JOIN save_counts sc ON sc.firm_id = f.firm_id AND sc.day = d::date
+WHERE extract(isodow FROM d) BETWEEN 1 AND 5
+${where}
+ORDER BY f.firm_id, business_day;"
+    ;;
+esac
+
+ssh oci 'docker exec -i main-postgres psql -X -q -U ssh_reports_hub -d ssh_reports_hub -v ON_ERROR_STOP=1 --csv -P pager=off' <<SQL
+${query}
+SQL

--- a/scripts/ops_report_data_snapshot.sh
+++ b/scripts/ops_report_data_snapshot.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Read-only production snapshot for tbl_sec_reports.
+# Emits one compact JSON object so an LLM can inspect the live data product
+# without traversing SSH, schema, scraper, and enrichment paths separately.
+set -euo pipefail
+
+days=7
+include_schema=false
+
+usage() {
+  cat <<'EOF'
+Usage: bash scripts/ops_report_data_snapshot.sh [--days N] [--schema]
+
+Read-only OCI snapshot of tbl_sec_reports. Default output is one compact JSON
+object covering freshness, delivery/archive state, and investment-data coverage
+for the latest N saved rows (default: 7 days). --schema appends physical columns.
+EOF
+}
+
+while (($#)); do
+  case "$1" in
+    --days)
+      [[ ${2:-} =~ ^[1-9][0-9]{0,3}$ ]] || { echo "--days must be 1..9999" >&2; exit 2; }
+      days=$2
+      shift 2
+      ;;
+    --schema)
+      include_schema=true
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+schema_sql="'[]'::jsonb"
+if [[ $include_schema == true ]]; then
+  schema_sql="(
+    SELECT coalesce(jsonb_agg(jsonb_build_object(
+      'name', column_name, 'type', data_type, 'nullable', (is_nullable = 'YES')
+    ) ORDER BY ordinal_position), '[]'::jsonb)
+    FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'tbl_sec_reports'
+  )"
+fi
+
+ssh oci 'docker exec -i main-postgres psql -X -q -U ssh_reports_hub -d ssh_reports_hub -At -v ON_ERROR_STOP=1' <<SQL
+WITH scope AS (
+  SELECT *
+  FROM public.tbl_sec_reports
+  WHERE save_at >= now() - interval '${days} days'
+), latest_by_firm AS (
+  SELECT firm_id, max(firm_nm) AS firm_nm, max(save_at) AS last_saved_at
+  FROM public.tbl_sec_reports
+  WHERE firm_id IS NOT NULL
+  GROUP BY firm_id
+), stale_firms AS (
+  SELECT coalesce(jsonb_agg(jsonb_build_object('firm_id', firm_id, 'firm_nm', firm_nm, 'last_saved_at', last_saved_at)
+    ORDER BY last_saved_at), '[]'::jsonb) AS items
+  FROM latest_by_firm
+  WHERE last_saved_at < now() - interval '48 hours'
+)
+SELECT jsonb_build_object(
+  'generated_at', now(),
+  'window_days', ${days},
+  'table', 'public.tbl_sec_reports',
+  'freshness', jsonb_build_object(
+    'total_rows', (SELECT count(*) FROM public.tbl_sec_reports),
+    'window_rows', (SELECT count(*) FROM scope),
+    'last_saved_at', (SELECT max(save_at) FROM public.tbl_sec_reports),
+    'last_report_date', (SELECT max(report_date) FROM public.tbl_sec_reports),
+    'future_dated_rows', (SELECT count(*) FROM public.tbl_sec_reports WHERE report_date > current_date)
+  ),
+  'core_quality', jsonb_build_object(
+    'missing_title', (SELECT count(*) FROM scope WHERE coalesce(nullif(btrim(article_title), ''), '') = ''),
+    'missing_pdf_url', (SELECT count(*) FROM scope WHERE coalesce(nullif(btrim(pdf_url), ''), '') = ''),
+    'missing_telegram_url', (SELECT count(*) FROM scope WHERE coalesce(nullif(btrim(telegram_url), ''), '') = '')
+  ),
+  'investment_coverage', jsonb_build_object(
+    'with_tickers', (SELECT count(*) FROM scope WHERE stock_tickers <> '[]'::jsonb),
+    'with_tags', (SELECT count(*) FROM scope WHERE tags <> '[]'::jsonb),
+    'with_article_text', (SELECT count(*) FROM scope WHERE article_text IS NOT NULL AND btrim(article_text) <> ''),
+    'with_llm_summary', (SELECT count(*) FROM scope WHERE gemini_summary IS NOT NULL AND btrim(gemini_summary) <> ''),
+    'with_target_price', (SELECT count(*) FROM scope WHERE target_price IS NOT NULL),
+    'with_fnguide_match', (SELECT count(*) FROM scope WHERE fnguide_summary_id IS NOT NULL)
+  ),
+  'pipeline_state', jsonb_build_object(
+    'by_sync_and_pdf_status', (
+      SELECT coalesce(jsonb_agg(jsonb_build_object('sync_status', sync_status, 'pdf_sync_status', pdf_sync_status, 'count', count)
+        ORDER BY count DESC), '[]'::jsonb)
+      FROM (
+        SELECT sync_status, pdf_sync_status, count(*) AS count
+        FROM scope GROUP BY sync_status, pdf_sync_status
+      ) status_counts
+    ),
+    'stale_firms_over_48h', (SELECT items FROM stale_firms)
+  ),
+  'schema', ${schema_sql}
+);
+SQL

--- a/tests/test_article_text.py
+++ b/tests/test_article_text.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from scrapers.article_text import extract_ds_summary
+from scrapers.article_text import extract_ds_summary, fetch_new_site_summaries
 
 
 def test_extract_ds_summary_strips_markup_and_entities():
@@ -21,3 +21,14 @@ def test_extract_ds_summary_returns_empty_for_missing_or_short_body():
 def test_extract_ds_summary_is_bounded():
     body = "가" * 20_000
     assert len(extract_ds_summary(f'<div id="bo_v_con">{body}</div>')) == 10_000
+
+
+def test_fetches_detail_only_for_new_ds_rows(monkeypatch):
+    monkeypatch.setattr("scrapers.article_text.fetch_ds_summary", lambda url: "DS 상세 요약 본문입니다." if "new" in url else "")
+    reports = [
+        {"firm_id": 11, "report_unique_key": "new", "source_url": "/detail/new"},
+        {"firm_id": 11, "report_unique_key": "old", "source_url": "/detail/old"},
+        {"firm_id": 1, "report_unique_key": "other", "source_url": "/detail/other"},
+    ]
+
+    assert fetch_new_site_summaries(reports, {"new"}) == {"new": "DS 상세 요약 본문입니다."}

--- a/tests/test_article_text.py
+++ b/tests/test_article_text.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scrapers.article_text import extract_ds_summary
+
+
+def test_extract_ds_summary_strips_markup_and_entities():
+    html = '''<div id="bo_v_con"><p>매출 &amp; 이익이 개선됩니다. 실적 추정치도 상향합니다.</p>
+    <strong>목표가 상향</strong></div>'''
+
+    assert extract_ds_summary(html) == "매출 & 이익이 개선됩니다. 실적 추정치도 상향합니다. 목표가 상향"
+
+
+def test_extract_ds_summary_returns_empty_for_missing_or_short_body():
+    assert extract_ds_summary("<html>no body</html>") == ""
+    assert extract_ds_summary('<div id="bo_v_con">짧음</div>') == ""
+
+
+def test_extract_ds_summary_is_bounded():
+    body = "가" * 20_000
+    assert len(extract_ds_summary(f'<div id="bo_v_con">{body}</div>')) == 10_000

--- a/tests/test_legacy_url_config.py
+++ b/tests/test_legacy_url_config.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scrapers.config_guard import ScraperConfigError
+from scrapers.legacy_url_config import FIRM_DEFAULTS, normalize_legacy_url_config
+
+
+@pytest.mark.parametrize("firm_key", sorted(FIRM_DEFAULTS))
+def test_url_list_receives_versioned_parser_defaults(firm_key):
+    config = normalize_legacy_url_config(["https://example.test/source"], firm_key=firm_key)
+
+    assert config["urls"] == ["https://example.test/source"]
+    for key in FIRM_DEFAULTS[firm_key]:
+        assert key in config
+    assert config != FIRM_DEFAULTS[firm_key]
+
+
+def test_explicit_config_overrides_defaults_without_losing_nested_keys():
+    config = normalize_legacy_url_config(
+        {
+            "urls": ["https://example.test/source"],
+            "headers": {"X-Test": "true"},
+            "item_keys": {"title": "custom_title"},
+        },
+        firm_key="Toss",
+    )
+
+    assert config["headers"]["X-Test"] == "true"
+    assert config["headers"]["User-Agent"]
+    assert config["item_keys"]["title"] == "custom_title"
+    assert config["item_keys"]["files"] == "files"
+
+
+def test_missing_urls_and_unknown_firm_fail_fast():
+    with pytest.raises(ScraperConfigError, match="no source URLs"):
+        normalize_legacy_url_config([], firm_key="Samsung")
+    with pytest.raises(ScraperConfigError, match="unknown legacy URL-list firm"):
+        normalize_legacy_url_config([], firm_key="Unknown")

--- a/tests/test_ls_attachment_resolution.py
+++ b/tests/test_ls_attachment_resolution.py
@@ -1,0 +1,77 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from modules import LS_0
+
+
+@pytest.mark.asyncio
+async def test_ls_detail_never_guesses_pdf_from_writer_history(monkeypatch):
+    """A missing attachment must stay unresolved, not borrow another report's PDF."""
+
+    async def fake_fetch(*_args, **_kwargs):
+        return """
+        <table><tr><th>제목</th><td>화장품 ODM 참 좋은데…</td></tr>
+        <tr><th>필명</th><td>오린아</td></tr>
+        <tr><th>첨부파일</th><td></td></tr></table>
+        """
+
+    async def must_not_run(*_args, **_kwargs):
+        raise AssertionError("writer-history URL inference must not run")
+
+    monkeypatch.setattr(LS_0, "fetch", fake_fetch)
+    monkeypatch.setattr(LS_0, "reconstruct_msg_url_from_db", must_not_run)
+
+    article = {
+        "report_unique_key": "https://www.ls-sec.co.kr/EtwFrontBoard/View.jsp?board_no=33&board_seq=1",
+        "report_date": "20260713",
+        "writer": "오린아",
+        "article_title": "화장품 ODM 참 좋은데…",
+    }
+
+    await LS_0.process_article(None, article, headers={})
+
+    assert article["telegram_url"] == ""
+    assert article["pdf_file_url"] == ""
+
+
+@pytest.mark.asyncio
+async def test_ls_detail_tries_same_date_inference_before_detail_page(monkeypatch):
+    inferred_calls = []
+    detail_calls = []
+
+    async def fake_reconstruct(article, _headers, exact_report_date=False):
+        inferred_calls.append((article["article_title"], exact_report_date))
+        if article["article_title"] == "목록에서 복구됨":
+            return "https://msg.ls-sec.co.kr/eum/K_20260713_1_2.pdf"
+        return None
+
+    async def fake_process(_session, article, _headers, db=None):
+        detail_calls.append(article["article_title"])
+
+    monkeypatch.setattr(LS_0, "reconstruct_msg_url_from_db", fake_reconstruct)
+    monkeypatch.setattr(LS_0, "process_article", fake_process)
+    monkeypatch.setattr(LS_0, "LS_DETAIL_DELAY_MIN", 0)
+    monkeypatch.setattr(LS_0, "LS_DETAIL_DELAY_MAX", 0)
+
+    resolved = {
+        "article_title": "목록에서 복구됨",
+        "report_date": "20260713",
+        "writer": "오린아",
+    }
+    unresolved = {
+        "article_title": "상세 페이지 필요",
+        "report_date": "20260713",
+        "writer": "오린아",
+    }
+
+    await LS_0.LS_detail([resolved, unresolved])
+
+    assert inferred_calls == [
+        ("목록에서 복구됨", True),
+        ("상세 페이지 필요", True),
+    ]
+    assert resolved["telegram_url"].endswith("K_20260713_1_2.pdf")
+    assert detail_calls == ["상세 페이지 필요"]

--- a/tests/test_ls_attachment_resolution.py
+++ b/tests/test_ls_attachment_resolution.py
@@ -42,8 +42,8 @@ async def test_ls_detail_tries_same_date_inference_before_detail_page(monkeypatc
     inferred_calls = []
     detail_calls = []
 
-    async def fake_reconstruct(article, _headers, exact_report_date=False):
-        inferred_calls.append((article["article_title"], exact_report_date))
+    async def fake_reconstruct(article, _headers, date_window_days=None):
+        inferred_calls.append((article["article_title"], date_window_days))
         if article["article_title"] == "목록에서 복구됨":
             return "https://msg.ls-sec.co.kr/eum/K_20260713_1_2.pdf"
         return None
@@ -70,8 +70,8 @@ async def test_ls_detail_tries_same_date_inference_before_detail_page(monkeypatc
     await LS_0.LS_detail([resolved, unresolved])
 
     assert inferred_calls == [
-        ("목록에서 복구됨", True),
-        ("상세 페이지 필요", True),
+        ("목록에서 복구됨", 3),
+        ("상세 페이지 필요", 3),
     ]
     assert resolved["telegram_url"].endswith("K_20260713_1_2.pdf")
     assert detail_calls == ["상세 페이지 필요"]

--- a/tests/test_sec_reports_manager.py
+++ b/tests/test_sec_reports_manager.py
@@ -166,6 +166,19 @@ def test_mark_reports_sent_marks_is_sent_and_legacy_main_channel_flag():
     assert calls[0][1] == (1,)  # default: report_id only, not match_by_url
 
 
+def test_save_article_text_only_fills_an_empty_field():
+    from models.SecReportsManager import SecReportsManager
+
+    calls = []
+    manager = object.__new__(SecReportsManager)
+    manager.table_name = "tbl_sec_reports"
+    manager._execute = lambda sql, params: calls.append((sql, params)) or {"rowcount": 1}
+
+    assert manager.save_article_text_if_empty("report-key", "사이트 상세 요약") == 1
+    assert "COALESCE(btrim(article_text), '') = ''" in calls[0][0]
+    assert calls[0][1] == ("사이트 상세 요약", "report-key")
+
+
 def test_update_telegram_url_accepts_pdf_file_url_alias():
     from models.SecReportsManager import SecReportsManager
 

--- a/tests/test_sec_reports_manager.py
+++ b/tests/test_sec_reports_manager.py
@@ -78,6 +78,7 @@ def test_insert_includes_legacy_and_canonical_keys(monkeypatch):
     assert "report_unique_key" in connection.cursor_instance.sql
     assert connection.cursor_instance.records[0][9] == "https://example.test/report.pdf"
     assert connection.cursor_instance.records[0][11] is not None  # save_at
+    assert connection.cursor_instance.records[0][12] == ""  # article_text
     assert connection.cursor_instance.records[0][10] is False
     assert "main_ch_send_yn     = CASE" not in connection.cursor_instance.sql
     assert "telegram_sent       = COALESCE" in connection.cursor_instance.sql
@@ -114,6 +115,36 @@ def test_insert_preserves_legacy_artifact_save_time(monkeypatch):
     assert connection.cursor_instance.records[0][11] == datetime.fromisoformat(
         "2026-06-15T08:00:00+09:00"
     )
+
+
+def test_insert_persists_site_article_text_without_overwriting_with_empty(monkeypatch):
+    from models.SecReportsManager import SecReportsManager
+
+    connection = FakeConnection()
+    manager = object.__new__(SecReportsManager)
+    manager.table_name = "tbl_sec_reports"
+    manager.get_connection = lambda: connection
+
+    def fake_execute_values(cursor, sql, records, page_size):
+        cursor.sql = sql
+        cursor.records = records
+
+    monkeypatch.setattr(
+        "models.SecReportsManager.psycopg2.extras.execute_values",
+        fake_execute_values,
+    )
+    manager.insert_json_data_list([{
+        "firm_id": 3,
+        "board_id": 0,
+        "firm_nm": "하나증권",
+        "article_title": "HTML summary",
+        "article_text": "증권사 사이트가 제공한 핵심 요약",
+        "report_unique_key": "hana-summary-key",
+    }])
+
+    assert connection.cursor_instance.records[0][12] == "증권사 사이트가 제공한 핵심 요약"
+    assert "article_text" in connection.cursor_instance.sql
+    assert "COALESCE(NULLIF(EXCLUDED.article_text, '')" in connection.cursor_instance.sql
 
 
 def test_mark_reports_sent_marks_is_sent_and_legacy_main_channel_flag():

--- a/tests/test_shinhan_core.py
+++ b/tests/test_shinhan_core.py
@@ -22,3 +22,30 @@ def test_canonical_shinhan_url_normalizes_legacy_domain_protocol_and_path():
     } == {
         "https://bbs2.shinhansec.com/board/message/file.pdf.do?attachmentId=351365"
     }
+
+
+def test_shinhan_mobile_item_keeps_detail_url_and_summary(monkeypatch):
+    from scrapers.shinhan_core import scrape_shinhan
+
+    class Response:
+        status_code = 200
+
+        def json(self):
+            return {
+                "header": {"resultCode": "00000", "repeatKeyN": ""},
+                "body": {"list01": {"outputList": [{
+                    "date": "2026.07.13",
+                    "attachment_url": "https://bbs2.shinhansec.com/board/message/file.pdf.do?attachmentId=1",
+                    "message_url": "https://m.shinhansec.com/mweb/invt/shrh/detail?id=1",
+                    "summary": "실적 추정 상향과 밸류에이션 재평가가 기대됩니다.",
+                    "title": "테스트", "nickname": "애널리스트",
+                }]}}
+            }
+
+    monkeypatch.setattr("scrapers.shinhan_core.requests.post", lambda *args, **kwargs: Response())
+    monkeypatch.setattr("scrapers.shinhan_core.requests.get", lambda *args, **kwargs: Response())
+    rows = scrape_shinhan({"str_boards": "gicompanyanalyst", "bbs_boards": []})
+
+    assert len(rows) == 1
+    assert rows[0]["article_text"] == "실적 추정 상향과 밸류에이션 재평가가 기대됩니다."
+    assert rows[0]["source_url"].endswith("id=1")

--- a/tests/test_site_summary_fields.py
+++ b/tests/test_site_summary_fields.py
@@ -1,0 +1,62 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def test_hmsec_keeps_contents_from_list_api(monkeypatch):
+    from scrapers.hmsec_core import scrape_hmsec
+
+    class Response:
+        def json(self):
+            return {
+                "data_list": [{
+                    "UPLOAD_FILE1": "report.pdf", "REG_DATE": "20260713",
+                    "SUBJECT": "테스트", "NAME": "애널리스트",
+                    "CONTENTS": "현대차증권이 제공한 리포트 요약",
+                }],
+                "paging": {"totalPages": 1},
+            }
+
+    monkeypatch.setattr("scrapers.hmsec_core.requests.get", lambda *args, **kwargs: Response())
+    rows = scrape_hmsec(["https://example.test/list"])
+
+    assert len(rows) == 1
+    assert rows[0]["article_text"] == "현대차증권이 제공한 리포트 요약"
+
+
+def test_shinyoung_keeps_summary_from_list_api(monkeypatch):
+    from scrapers.shinyoung_core import scrape_shinyoung
+
+    class Response:
+        def __init__(self, payload=None, text=""):
+            self._payload = payload
+            self.text = text
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    class Session:
+        def __init__(self):
+            self.calls = 0
+
+        def post(self, *args, **kwargs):
+            self.calls += 1
+            if self.calls == 1:
+                return Response({"rows": [{
+                    "TITLE": "테스트", "APPDATE": "2026.07.13", "EMPNM": "애널리스트",
+                    "SEQ": "1", "BBSNO": "2", "SUMMARY": "신영증권이 제공한 리포트 요약",
+                }]})
+            if self.calls == 4:
+                return Response(text=json.dumps({"FILEINFO": {"FILEPATH": "report.pdf"}}))
+            return Response()
+
+    monkeypatch.setattr("scrapers.shinyoung_core.requests.Session", Session)
+    rows = scrape_shinyoung({"list_url": "https://example.test/list", "urls": ["https://example.test/list", "https://example.test/files/"]})
+
+    assert len(rows) == 1
+    assert rows[0]["article_text"] == "신영증권이 제공한 리포트 요약"


### PR DESCRIPTION
- restore GA URL-list scraper compatibility\n- retain broker-provided summaries and fetch new detail summaries once\n- resolve LS PDF URLs from listing date ±3 days before detail fallback\n- regression coverage added