### PR TITLE
fix: restore DS internal share links for Telegram

### DIFF
--- a/models/report_payload.py
+++ b/models/report_payload.py
@@ -54,7 +54,14 @@ class ReportPayload:
             raise ReportPayloadError("missing firm_nm")
 
         save_at = _parse_save_at(item)
-        telegram_url = str(item.get("telegram_url") or source_url).strip()
+        # DS uses an empty telegram_url as an explicit DB-trigger signal: after
+        # report_id allocation it becomes the internal /share?id=<report_id>
+        # URL. Do not replace that signal with the public broker detail page.
+        raw_telegram_url = item.get("telegram_url")
+        if item.get("firm_id") == 11 and not str(raw_telegram_url or "").strip():
+            telegram_url = ""
+        else:
+            telegram_url = str(raw_telegram_url or source_url).strip()
         pdf_file_url = str(
             item.get("pdf_file_url") or item.get("pdf_url") or telegram_url
         ).strip()

--- a/tests/test_report_payload_contract.py
+++ b/tests/test_report_payload_contract.py
@@ -26,6 +26,21 @@ def test_scraper_aliases_are_mapped_to_physical_db_fields():
     assert record[9] == "https://example.test/article"  # report_unique_key
 
 
+def test_ds_empty_telegram_url_is_preserved_for_internal_share_trigger():
+    payload = ReportPayload.from_scraper({
+        "firm_id": 11,
+        "firm_nm": "DS투자증권",
+        "report_date": "20260714",
+        "article_title": "Report",
+        "source_url": "https://www.ds-sec.co.kr/bbs/board.php?wr_id=1",
+        "telegram_url": "",
+        "pdf_file_url": "https://www.ds-sec.co.kr/bbs/download.php?wr_id=1",
+    })
+
+    assert payload.telegram_url == ""
+    assert payload.pdf_file_url.endswith("wr_id=1")
+
+
 def test_legacy_save_time_is_an_explicit_artifact_adapter():
     payload = ReportPayload.from_scraper({
         "report_unique_key": "legacy",


### PR DESCRIPTION
Preserve DS empty telegram_url so the existing DB trigger assigns internal /share?id=<report_id> links. Includes regression coverage. Existing 36 DS detail links were backfilled to share URLs in production.