### PR TITLE
refactor: expose Yuanta scraper failures

### DIFF
--- a/scrapers/yuanta_core.py
+++ b/scrapers/yuanta_core.py
@@ -32,7 +32,10 @@ def scrape_yuanta(cfg: dict) -> list[dict]:
             try:
                 resp = requests.get(url, headers=cfg["headers"], timeout=30, verify=False)
                 if resp.status_code != 200: break
-            except Exception: break
+            except Exception as exc:
+                print(f"[yuanta] request failed board={code} page={page} ({type(exc).__name__})",
+                      file=sys.stderr)
+                break
             soup = BeautifulSoup(resp.text, "html.parser")
             items = soup.select(cfg["row_sel"])
             if not items: break

--- a/tests/test_yuanta_error_context.py
+++ b/tests/test_yuanta_error_context.py
@@ -1,0 +1,23 @@
+"""Verify Yuanta request failure logs diagnostic and preserves return."""
+import sys
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def test_yuanta_request_failure_logs_and_returns_partial(capsys):
+    from scrapers.yuanta_core import scrape_yuanta
+
+    with mock.patch("scrapers.yuanta_core.requests.get") as fake_get:
+        fake_get.side_effect = ConnectionError("no route")
+        result = scrape_yuanta({
+            "urls": ["https://test.test/yuanta"], "board_codes": ["001"],
+        })
+
+    assert isinstance(result, list)
+    captured = capsys.readouterr()
+    assert "[yuanta] request failed board=001 page=1" in captured.err
+    assert "ConnectionError" in captured.err
+    assert "no route" not in captured.err  # private message not exposed


### PR DESCRIPTION
## Change
- expose the board, page, and exception type when Yuanta request failure would otherwise silently end pagination
- preserve break, pagination, payload, retry, and return behavior
- do not emit private exception messages or URLs

## Validation
- focused test: 1 passed
- py_compile, diff check, and push hook: passed