### PR TITLE
fix(hana): remove artificial future date adjustment

### DIFF
--- a/models/SecReportsManager.py
+++ b/models/SecReportsManager.py
@@ -237,10 +237,12 @@ class SecReportsManager(LibrarySecReportsManager):
         """
         if date_str is None:
             query_date = datetime.now().strftime("%Y-%m-%d")
-            query_report_date_end = (datetime.now() + timedelta(days=2)).date()
+            # 2026-07-31 fix: +4일로 확장. Friday 17시+ 리포트 → Monday(+3일)까지 커버.
+            # 기존 +2일은 금요일 장 마감 후 익영업일(월요일) 리포트가 윈도우 밖으로 밀려남.
+            query_report_date_end = (datetime.now() + timedelta(days=4)).date()
         else:
             query_date = f"{date_str[:4]}-{date_str[4:6]}-{date_str[6:]}"
-            query_report_date_end = (datetime.strptime(date_str, "%Y%m%d") + timedelta(days=2)).date()
+            query_report_date_end = (datetime.strptime(date_str, "%Y%m%d") + timedelta(days=4)).date()
 
         three_days_ago = (datetime.now() - timedelta(days=3)).date()
 

--- a/scrapers/hana_core.py
+++ b/scrapers/hana_core.py
@@ -12,7 +12,11 @@ def _adjust_date(report_date, time_str):
     if period == "오후" and hour != 12: hour += 12
     elif period == "오전" and hour == 12: hour = 0
     reg_date += timedelta(hours=hour, minutes=int(minute))
-    if reg_date.hour >= 10: reg_date += timedelta(days=1)
+    # 2026-07-31 fix: 다음 영업일 cutoff를 10시 → 17시로 수정.
+    # 장 마감(15:30) 이후 등록된 리포트는 익영업일 날짜를 부여.
+    # 기존 hour>=10 은 오전 리포트까지 익일로 밀어내는 버그.
+    # 17시 이후 → +1일 → 주말이면 월요일로 스킵.
+    if reg_date.hour >= 17: reg_date += timedelta(days=1)
     while reg_date.weekday() >= 5: reg_date += timedelta(days=1)
     return reg_date.strftime("%Y%m%d")
 


### PR DESCRIPTION
## 문제
`_adjust_date()`의 `hour >= 10 → +1일` 로직이 오전 리포트까지 익영업일로 밀어내고,
`select_reports_ready_for_telegram()`의 `report_date <= today+2` 윈도우가
Friday→Monday(+3일) 리포트를 발송 대상에서 제외.

금요일 하나증권 리포트 9건이 발송 누락 + 프론트 미노출.

## 수정 (2개 파일)

### 1. `scrapers/hana_core.py` — cutoff 10시 → 17시
- 장 마감(15:30) 이후 등록된 리포트만 익영업일 날짜 부여
- Friday 17:00+ → Monday (주말 스킵 유지)
- 오전/이른 오후 리포트는 당일 날짜 유지

### 2. `models/SecReportsManager.py` — 발송 윈도우 +2일 → +4일
- Friday → Monday(+3일) 리포트가 발송 쿼리에 포함되도록 확장
- `save_at` 필터로 최근 스크래핑 건만 조회하므로 stale 위험 없음

## DB 보정 완료 (운영)
- 2026-07-31 하나증권 9건: report_date 수정 + 텔레그램 재발송 완료
- 현재 프론트엔드 정상 노출 확인 (/recent API 검증)

## Git 히스토리
- `587a2f9`: fix(hana): remove artificial future date adjustments
- `cd39b85`: fix: restore Hana adjust date weekend logic (잘못된 롤백)

🤖 Generated with [Claude Code](https://claude.com/claude-code)