### PR TITLE
fix(ls): use latest DB sequence for PDF fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,10 @@ ENV PYTHONUNBUFFERED=1
 RUN apt-get update && apt-get install -y \
     wget \
     ca-certificates \
+    poppler-utils \
     rclone \
+    tesseract-ocr \
+    tesseract-ocr-kor \
     chromium \
     chromium-driver \
     && rm -rf /var/lib/apt/lists/*

--- a/modules/LS_0.py
+++ b/modules/LS_0.py
@@ -21,6 +21,7 @@ from models.WebScraper import SyncWebScraper
 from models.FirmInfo import FirmInfo
 from models.db_factory import get_db
 from models.ConfigManager import config
+from utils.ls_pdf_verifier import verify_ls_pdf_candidate
 
 import urllib3
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -280,7 +281,12 @@ async def fetch(session: ClientSession, url: str, headers: dict) -> str:
                 logger.error(f"LS WARP 상세 요청 최종 실패 (시도 {attempt}/{LS_WARP_RETRIES}): {url} ({e})")
                 return None
 
-async def process_article(session: ClientSession, article: dict, headers: dict, db=None):
+async def process_article(
+    session: ClientSession,
+    article: dict,
+    headers: dict,
+    db=None,
+):
     TARGET_URL = _article_unique_key(article)
 
     if ".pdf" in TARGET_URL:
@@ -315,11 +321,11 @@ async def process_article(session: ClientSession, article: dict, headers: dict, 
 
             if th_text == "제목":
                 article["article_title"] = td_text
-            elif th_text == "필명":
-                # 상세 페이지에서 writer 확보 → reconstruct_msg_url_from_db()에서 emp_id 추론 가능
+            elif th_text in {"작성자", "필명"}:
+                # The live board uses 작성자 while older rows use 필명.
                 if td_text:
                     article["writer"] = td_text
-                    logger.debug(f"[LS][필명추출] writer={td_text}")
+                    logger.debug(f"[LS][작성자추출] writer={td_text}")
             elif th_text == "첨부파일":
                 # ── URL 해결 전략 (3단계) ──
                 # 1순위: 업로드 파일명 직접 파싱 → CDN URL (가장 빠름)
@@ -381,6 +387,27 @@ async def process_article(session: ClientSession, article: dict, headers: dict, 
                     )
                     logger.debug(f"[건별업데이트] report_id={article['report_id']}: {article.get('article_title')}")
 
+    # A same-writer history URL is not attachment evidence.  Only use it when
+    # this detail page has no attachment, and make the candidate prove its
+    # identity from the first PDF page before assigning it.
+    if not article.get("telegram_url"):
+        inferred_url = await reconstruct_msg_url_from_db(
+            article,
+            headers,
+            date_window_days=0,
+        )
+        if inferred_url:
+            article["source_url"] = inferred_url
+            article["telegram_url"] = inferred_url
+            article["pdf_file_url"] = inferred_url
+            if db and article.get("report_id"):
+                await db.update_telegram_url(
+                    record_id=article["report_id"],
+                    telegram_url=inferred_url,
+                    article_title=article.get("article_title"),
+                    pdf_file_url=inferred_url,
+                )
+
 async def LS_detail(articles, firm_info=None, db=None):
     if isinstance(articles, dict):
         articles = [articles]
@@ -400,38 +427,21 @@ async def LS_detail(articles, firm_info=None, db=None):
 
     async def sem_process_article(session, article):
         async with semaphore:
-            await process_article(session, article, headers, db=db)
+            await process_article(
+                session,
+                article,
+                headers,
+                db=db,
+            )
             import random
             await asyncio.sleep(random.uniform(LS_DETAIL_DELAY_MIN, LS_DETAIL_DELAY_MAX))
 
-    # 목록의 report_date와 writer 이력으로 인접 3일 이내 CDN URL만 먼저 찾는다.
-    # 기존 백필용 광범위 탐색(±LS_SEARCH_DAYS)과 분리해 다른 게시물 PDF 오연결을
-    # 막고, 이 범위에서 못 찾은 건만 상세 페이지를 한 번 조회해 첨부파일명을 읽는다.
-    detail_targets = []
-    for article in articles:
-        if str(article.get("telegram_url", "")).lower().endswith(".pdf"):
-            continue
-        inferred_url = await reconstruct_msg_url_from_db(
-            article, headers, date_window_days=3
-        )
-        if not inferred_url:
-            detail_targets.append(article)
-            continue
-
-        article["source_url"] = inferred_url
-        article["telegram_url"] = inferred_url
-        article["pdf_file_url"] = inferred_url
-        logger.info(
-            "[LS][목록추론] report_date={} PDF 복구: {}",
-            _article_report_date(article), inferred_url,
-        )
-        if db and article.get("report_id"):
-            await db.update_telegram_url(
-                record_id=article["report_id"],
-                telegram_url=inferred_url,
-                article_title=article.get("article_title"),
-                pdf_file_url=inferred_url,
-            )
+    # Detail attachments are the source of truth.  Do not let a same-writer
+    # CDN probe resolve a row before its own board page is inspected.
+    detail_targets = [
+        article for article in articles
+        if not str(article.get("telegram_url", "")).lower().endswith(".pdf")
+    ]
 
     async with aiohttp.ClientSession() as session:
         tasks = [sem_process_article(session, article) for article in detail_targets]
@@ -567,7 +577,11 @@ async def create_fallback_url(article, soup=None):
     
     return ""
 
-async def reconstruct_msg_url_from_db(article, headers, date_window_days=None):
+async def reconstruct_msg_url_from_db(
+    article,
+    headers,
+    date_window_days=None,
+):
     """DB에 있는 성공한 msg URL 데이터를 기반으로 writer ID와 seq를 추론해서 msg URL 재구성.
 
     동일 작성자의 기존 성공 URL에서 writer_id(emp_id)와 seq 패턴을 추출하여
@@ -687,9 +701,14 @@ async def reconstruct_msg_url_from_db(article, headers, date_window_days=None):
             day_offsets.extend((offset, -offset))
         for day_offset in day_offsets:
             test_date = (base_date + timedelta(days=day_offset)).strftime("%Y%m%d")
-            # seq: 예상값 기준 ±50, 최소 1
-            for seq_offset in range(-50, 51):
-                test_seq = max(1, est_seq + seq_offset)
+            # LS_detail is intentionally sequential.  After each successful
+            # row is persisted, the next row opens a fresh DB manager and uses
+            # the latest committed max_seq: 935 -> 936 -> 937.
+            seq_start = max(1, max_seq + 1)
+            seq_values = [seq_start]
+            for seq_offset in range(1, 51):
+                seq_values.extend((seq_start + seq_offset, max(1, est_seq - seq_offset)))
+            for test_seq in dict.fromkeys(seq_values):
                 test_url = f"{LS_MSG_EUM_PREFIX}/K_{test_date}_{writer_id}_{test_seq}.pdf"
                 candidates.append(test_url)
 
@@ -708,7 +727,16 @@ async def reconstruct_msg_url_from_db(article, headers, date_window_days=None):
                         lambda: requests.get(url, headers=headers, proxies=PROXIES,
                                             verify=False, timeout=10)
                     )
-                    if resp.status_code == 200:
+                    if resp.status_code != 200:
+                        return None
+                    verification = await asyncio.to_thread(
+                        verify_ls_pdf_candidate,
+                        url,
+                        article.get("article_title", ""),
+                        headers,
+                        PROXIES,
+                    )
+                    if verification.matched:
                         return url
                 except Exception:
                     pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "lxml>=6.0.2",
     "openpyxl>=3.1.5",
     "pandas>=3.0.1",
+    "pypdf>=6.0.0",
     "psycopg2-binary>=2.9.10",
     "python-dotenv>=1.2.2",
     "python-telegram-bot>=22.6",

--- a/tests/test_ls_attachment_resolution.py
+++ b/tests/test_ls_attachment_resolution.py
@@ -5,11 +5,12 @@ import pytest
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from modules import LS_0
+from utils.ls_pdf_verifier import PdfVerificationResult
 
 
 @pytest.mark.asyncio
-async def test_ls_detail_never_guesses_pdf_from_writer_history(monkeypatch):
-    """A missing attachment must stay unresolved, not borrow another report's PDF."""
+async def test_ls_detail_falls_back_only_after_attachment_is_absent(monkeypatch):
+    """Writer-history fallback runs only after this row's detail page is read."""
 
     async def fake_fetch(*_args, **_kwargs):
         return """
@@ -18,11 +19,14 @@ async def test_ls_detail_never_guesses_pdf_from_writer_history(monkeypatch):
         <tr><th>첨부파일</th><td></td></tr></table>
         """
 
-    async def must_not_run(*_args, **_kwargs):
-        raise AssertionError("writer-history URL inference must not run")
+    calls = []
+
+    async def fake_reconstruct(*_args, **kwargs):
+        calls.append(kwargs)
+        return None
 
     monkeypatch.setattr(LS_0, "fetch", fake_fetch)
-    monkeypatch.setattr(LS_0, "reconstruct_msg_url_from_db", must_not_run)
+    monkeypatch.setattr(LS_0, "reconstruct_msg_url_from_db", fake_reconstruct)
 
     article = {
         "report_unique_key": "https://www.ls-sec.co.kr/EtwFrontBoard/View.jsp?board_no=33&board_seq=1",
@@ -35,43 +39,71 @@ async def test_ls_detail_never_guesses_pdf_from_writer_history(monkeypatch):
 
     assert article["telegram_url"] == ""
     assert article["pdf_file_url"] == ""
+    assert calls == [{"date_window_days": 0}]
 
 
 @pytest.mark.asyncio
-async def test_ls_detail_tries_same_date_inference_before_detail_page(monkeypatch):
-    inferred_calls = []
+async def test_ls_detail_processes_rows_sequentially(monkeypatch):
     detail_calls = []
-
-    async def fake_reconstruct(article, _headers, date_window_days=None):
-        inferred_calls.append((article["article_title"], date_window_days))
-        if article["article_title"] == "목록에서 복구됨":
-            return "https://msg.ls-sec.co.kr/eum/K_20260713_1_2.pdf"
-        return None
 
     async def fake_process(_session, article, _headers, db=None):
         detail_calls.append(article["article_title"])
 
-    monkeypatch.setattr(LS_0, "reconstruct_msg_url_from_db", fake_reconstruct)
     monkeypatch.setattr(LS_0, "process_article", fake_process)
     monkeypatch.setattr(LS_0, "LS_DETAIL_DELAY_MIN", 0)
     monkeypatch.setattr(LS_0, "LS_DETAIL_DELAY_MAX", 0)
 
-    resolved = {
-        "article_title": "목록에서 복구됨",
+    first = {
+        "article_title": "첫 번째 상세 페이지",
         "report_date": "20260713",
         "writer": "오린아",
     }
-    unresolved = {
-        "article_title": "상세 페이지 필요",
+    second = {
+        "article_title": "두 번째 상세 페이지",
         "report_date": "20260713",
         "writer": "오린아",
     }
 
-    await LS_0.LS_detail([resolved, unresolved])
+    await LS_0.LS_detail([first, second])
 
-    assert inferred_calls == [
-        ("목록에서 복구됨", 3),
-        ("상세 페이지 필요", 3),
-    ]
-    assert resolved["telegram_url"].endswith("K_20260713_1_2.pdf")
-    assert detail_calls == ["상세 페이지 필요"]
+    assert detail_calls == ["첫 번째 상세 페이지", "두 번째 상세 페이지"]
+
+
+@pytest.mark.asyncio
+async def test_ls_fallback_reloads_latest_db_sequence_for_same_writer(monkeypatch):
+    class FakeDb:
+        def __init__(self, latest_sequence):
+            self.latest_sequence = latest_sequence
+
+        def _fetchall(self, query, _params):
+            if "WHERE firm_id = 0\n              AND writer" in query:
+                return [{"telegram_url": f"https://msg.ls-sec.co.kr/eum/K_20260803_31447_{self.latest_sequence}.pdf"}]
+            return [{
+                "telegram_url": f"https://msg.ls-sec.co.kr/eum/K_20260803_31447_{self.latest_sequence}.pdf",
+                "report_date": "2026-08-03",
+            }]
+
+    class FakeResponse:
+        status_code = 200
+
+    latest_sequences = iter((935, 936))
+    monkeypatch.setattr("models.db_factory.get_db", lambda: FakeDb(next(latest_sequences)))
+    monkeypatch.setattr(LS_0.requests, "get", lambda *_args, **_kwargs: FakeResponse())
+
+    def fake_verify(url, expected_title, *_args):
+        sequence = url.rsplit("_", 1)[-1].removesuffix(".pdf")
+        return PdfVerificationResult(sequence == expected_title, "test")
+
+    monkeypatch.setattr(LS_0, "verify_ls_pdf_candidate", fake_verify)
+    first = {"writer": "전배승", "report_date": "20260803", "article_title": "936"}
+    second = {"writer": "전배승", "report_date": "20260803", "article_title": "937"}
+
+    first_url = await LS_0.reconstruct_msg_url_from_db(
+        first, {}, date_window_days=0
+    )
+    second_url = await LS_0.reconstruct_msg_url_from_db(
+        second, {}, date_window_days=0
+    )
+
+    assert first_url.endswith("_936.pdf")
+    assert second_url.endswith("_937.pdf")

--- a/tests/test_ls_pdf_verifier.py
+++ b/tests/test_ls_pdf_verifier.py
@@ -1,0 +1,17 @@
+from utils.ls_pdf_verifier import normalize_ls_title, title_matches_pdf
+
+
+def test_title_matching_accepts_exact_title_with_formatting_noise():
+    expected = "[김윤정 ESG] 정책발 받는 시장4: 하반기 정책, MSCI 기준·대만 사례 비교"
+    observed = "LS Securities Research\n정책발 받는 시장4: 하반기 정책, MSCI 기준 대만 사례 비교"
+    assert title_matches_pdf(expected, observed)
+
+
+def test_title_matching_rejects_a_different_report_with_some_generic_terms():
+    expected = "정책발 받는 시장4: 하반기 정책, MSCI 기준·대만 사례 비교"
+    observed = "테크/모빌리티 Weekly | 반도체 기술적 약세장 진입"
+    assert not title_matches_pdf(expected, observed)
+
+
+def test_normalize_title_removes_bracketed_author_and_punctuation():
+    assert normalize_ls_title("[김윤정 ESG] 정책발: MSCI") == "정책발msci"

--- a/utils/ls_pdf_verifier.py
+++ b/utils/ls_pdf_verifier.py
@@ -1,0 +1,119 @@
+"""Bounded content verification for LS CDN URLs inferred without an attachment."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+import unicodedata
+
+import requests
+from pypdf import PdfReader
+
+
+MAX_PDF_BYTES = 20 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class PdfVerificationResult:
+    matched: bool
+    reason: str
+
+
+def normalize_ls_title(value: str) -> str:
+    """Make Korean/English report titles comparable without fuzzy guessing."""
+    value = unicodedata.normalize("NFKC", value or "").lower()
+    value = re.sub(r"^\s*\[[^\]]+\]\s*", "", value)
+    return "".join(re.findall(r"[가-힣a-z0-9]+", value))
+
+
+def title_matches_pdf(expected_title: str, extracted_text: str) -> bool:
+    expected = normalize_ls_title(expected_title)
+    observed = normalize_ls_title(extracted_text)
+    if not expected or not observed:
+        return False
+    if expected in observed:
+        return True
+
+    # Never accept scattered title words from the body.  Board titles are
+    # commonly stored with an ellipsis, and their normalized prefix still
+    # appears contiguously in the PDF title.  A false negative is safe here;
+    # a false positive republishes the wrong research report.
+    return False
+
+
+def _ocr_first_page(pdf_bytes: bytes) -> str:
+    """OCR only PDFs with no extractable text; the image is never persisted."""
+    with tempfile.TemporaryDirectory(prefix="ls-pdf-ocr-") as tmp:
+        root = Path(tmp)
+        pdf_path = root / "candidate.pdf"
+        pdf_path.write_bytes(pdf_bytes)
+        image_prefix = root / "page"
+        subprocess.run(
+            ["pdftoppm", "-f", "1", "-l", "1", "-r", "150", "-png", str(pdf_path), str(image_prefix)],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=20,
+        )
+        images = list(root.glob("page-*.png"))
+        if not images:
+            return ""
+        completed = subprocess.run(
+            ["tesseract", str(images[0]), "stdout", "-l", "kor+eng", "--psm", "6"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        return completed.stdout
+
+
+def verify_ls_pdf_candidate(url: str, expected_title: str, headers: dict, proxies: dict | None = None) -> PdfVerificationResult:
+    """Accept an inferred URL only when the first page proves its identity."""
+    if not expected_title:
+        return PdfVerificationResult(False, "missing expected article title")
+
+    try:
+        response = requests.get(url, headers=headers, proxies=proxies, verify=False, timeout=20, stream=True)
+        if response.status_code != 200:
+            return PdfVerificationResult(False, f"HTTP {response.status_code}")
+        chunks: list[bytes] = []
+        size = 0
+        for chunk in response.iter_content(64 * 1024):
+            if not chunk:
+                continue
+            size += len(chunk)
+            if size > MAX_PDF_BYTES:
+                return PdfVerificationResult(False, "PDF exceeds verification size limit")
+            chunks.append(chunk)
+        pdf_bytes = b"".join(chunks)
+    except Exception as exc:
+        return PdfVerificationResult(False, f"download failed: {type(exc).__name__}")
+
+    if not pdf_bytes.startswith(b"%PDF-"):
+        return PdfVerificationResult(False, "response is not a PDF")
+
+    try:
+        reader = PdfReader(BytesIO(pdf_bytes))
+        first_page_text = reader.pages[0].extract_text() or ""
+    except Exception as exc:
+        return PdfVerificationResult(False, f"PDF parse failed: {type(exc).__name__}")
+
+    if normalize_ls_title(first_page_text):
+        return PdfVerificationResult(
+            title_matches_pdf(expected_title, first_page_text),
+            "first-page text matched" if title_matches_pdf(expected_title, first_page_text) else "first-page text title mismatch",
+        )
+
+    try:
+        ocr_text = _ocr_first_page(pdf_bytes)
+    except Exception as exc:
+        return PdfVerificationResult(False, f"OCR failed: {type(exc).__name__}")
+    return PdfVerificationResult(
+        title_matches_pdf(expected_title, ocr_text),
+        "first-page OCR matched" if title_matches_pdf(expected_title, ocr_text) else "first-page OCR title mismatch",
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1454,6 +1454,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pypdf"
+version = "6.14.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/72/7dfd5ff1c9c37de97a731701f51af091325f123d9d4270361c9c69e4431f/pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25", size = 6491182 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/e6/136aa8993a2ae7214e0b0ef2edaa0d2e08d1d4e4982635b08a835ff31ec8/pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946", size = 349514 },
+]
+
+[[package]]
 name = "pysocks"
 version = "1.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1677,6 +1686,7 @@ dependencies = [
     { name = "openpyxl" },
     { name = "pandas" },
     { name = "psycopg2-binary" },
+    { name = "pypdf" },
     { name = "python-dotenv" },
     { name = "python-telegram-bot" },
     { name = "pytz" },
@@ -1708,6 +1718,7 @@ requires-dist = [
     { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "pandas", specifier = ">=3.0.1" },
     { name = "psycopg2-binary", specifier = ">=2.9.10" },
+    { name = "pypdf", specifier = ">=6.0.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-telegram-bot", specifier = ">=22.6" },
     { name = "pytz", specifier = ">=2026.1.post1" },


### PR DESCRIPTION
- Process LS detail attachments before writer-history fallback\n- Reload committed DB max_seq for each sequential row\n- Verify inferred PDF first-page title\n- Add pypdf and OCR runtime dependencies\n\nValidation: LS-focused tests 45 passed; Dockerfile copy verification passed.\n\nProduction correction: report_id 253187260 was updated from _936 to _937 without resend.