### PR TITLE
fix(hana): apply 18h business-day report cutoff

### DIFF
--- a/models/SecReportsManager.py
+++ b/models/SecReportsManager.py
@@ -237,10 +237,12 @@ class SecReportsManager(LibrarySecReportsManager):
         """
         if date_str is None:
             query_date = datetime.now().strftime("%Y-%m-%d")
-            query_report_date_end = (datetime.now() + timedelta(days=2)).date()
+            # 2026-07-31 fix: +4일로 확장. Friday 17시+ 리포트 → Monday(+3일)까지 커버.
+            # 기존 +2일은 금요일 장 마감 후 익영업일(월요일) 리포트가 윈도우 밖으로 밀려남.
+            query_report_date_end = (datetime.now() + timedelta(days=4)).date()
         else:
             query_date = f"{date_str[:4]}-{date_str[4:6]}-{date_str[6:]}"
-            query_report_date_end = (datetime.strptime(date_str, "%Y%m%d") + timedelta(days=2)).date()
+            query_report_date_end = (datetime.strptime(date_str, "%Y%m%d") + timedelta(days=4)).date()
 
         three_days_ago = (datetime.now() - timedelta(days=3)).date()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "chardet>=5.2.0,<6.0.0",
     "finvizfinance>=1.3.0",
     "google-generativeai>=0.8.6",
+    "holidays>=0.91",
     "loguru>=0.7.3",
     "lxml>=6.0.2",
     "openpyxl>=3.1.5",

--- a/scrapers/hana_core.py
+++ b/scrapers/hana_core.py
@@ -12,7 +12,11 @@ def _adjust_date(report_date, time_str):
     if period == "오후" and hour != 12: hour += 12
     elif period == "오전" and hour == 12: hour = 0
     reg_date += timedelta(hours=hour, minutes=int(minute))
-    if reg_date.hour >= 10: reg_date += timedelta(days=1)
+    # 2026-07-31 fix: 다음 영업일 cutoff를 10시 → 17시로 수정.
+    # 장 마감(15:30) 이후 등록된 리포트는 익영업일 날짜를 부여.
+    # 기존 hour>=10 은 오전 리포트까지 익일로 밀어내는 버그.
+    # 17시 이후 → +1일 → 주말이면 월요일로 스킵.
+    if reg_date.hour >= 17: reg_date += timedelta(days=1)
     while reg_date.weekday() >= 5: reg_date += timedelta(days=1)
     return reg_date.strftime("%Y%m%d")
 

--- a/scrapers/hana_core.py
+++ b/scrapers/hana_core.py
@@ -3,21 +3,40 @@ import sys
 import re, requests
 from datetime import datetime, timezone, timedelta
 from bs4 import BeautifulSoup
+import holidays
 
 def _adjust_date(report_date, time_str):
+    """Apply Hana's KST reporting-date cutover on the source publication date.
+
+    A report posted on a Korean non-business day belongs to the next business
+    day regardless of time.  On a business day only, 18:00 inclusive rolls to
+    the next business day.
+    """
     reg_date = datetime.strptime(report_date, "%Y%m%d")
+    kr_holidays = holidays.KR(years=range(reg_date.year - 1, reg_date.year + 3))
+
+    def is_business_day(value):
+        return value.weekday() < 5 and value.date() not in kr_holidays
+
+    def next_business_day(value):
+        value += timedelta(days=1)
+        while not is_business_day(value):
+            value += timedelta(days=1)
+        return value
+
     m = re.match(r"(오전|오후)?\s*(\d{1,2}):(\d{2})", time_str.strip())
-    if not m: return report_date
+    if not is_business_day(reg_date):
+        return next_business_day(reg_date).strftime("%Y%m%d")
+    if not m:
+        return report_date
     period, hour, minute = m.groups(); hour = int(hour)
-    if period == "오후" and hour != 12: hour += 12
+    # The source has emitted both 12-hour (오후 6:00) and 24-hour
+    # (오후 18:00) forms; do not add twelve hours to the latter.
+    if period == "오후" and hour < 12: hour += 12
     elif period == "오전" and hour == 12: hour = 0
     reg_date += timedelta(hours=hour, minutes=int(minute))
-    # 2026-07-31 fix: 다음 영업일 cutoff를 10시 → 17시로 수정.
-    # 장 마감(15:30) 이후 등록된 리포트는 익영업일 날짜를 부여.
-    # 기존 hour>=10 은 오전 리포트까지 익일로 밀어내는 버그.
-    # 17시 이후 → +1일 → 주말이면 월요일로 스킵.
-    if reg_date.hour >= 17: reg_date += timedelta(days=1)
-    while reg_date.weekday() >= 5: reg_date += timedelta(days=1)
+    if (reg_date.hour, reg_date.minute) >= (18, 0):
+        reg_date = next_business_day(reg_date)
     return reg_date.strftime("%Y%m%d")
 
 def scrape_hana(cfg: dict) -> list[dict]:

--- a/tests/test_hana_core.py
+++ b/tests/test_hana_core.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scrapers.hana_core import _adjust_date
+
+
+def test_hana_business_day_before_cutover_keeps_source_date():
+    assert _adjust_date("20260803", "오후 17:59") == "20260803"
+
+
+def test_hana_business_day_at_cutover_uses_next_business_day():
+    assert _adjust_date("20260803", "오후 6:00") == "20260804"
+
+
+def test_hana_friday_after_cutover_skips_weekend():
+    assert _adjust_date("20260807", "오후 18:00") == "20260810"
+
+
+def test_hana_weekend_ignores_time_and_uses_next_business_day():
+    assert _adjust_date("20260802", "오전 09:00") == "20260803"
+
+
+def test_hana_holiday_ignores_missing_time_and_uses_next_business_day():
+    # 2026-08-17 is the observed Liberation Day holiday in Korea.
+    assert _adjust_date("20260817", "") == "20260818"

--- a/uv.lock
+++ b/uv.lock
@@ -734,6 +734,18 @@ wheels = [
 ]
 
 [[package]]
+name = "holidays"
+version = "0.101"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/9c/1b4fbc0757e110704b55d81890b0f7e00d98d6d2e9900b96ba0f3abd4f52/holidays-0.101.tar.gz", hash = "sha256:fbaa802d66e5d24877359ae68c46d00a73437162d3e9a17466fe6cfcce123c3a", size = 956805 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/73/f004ae0e18a87408cef57191eac8d742c2906d9a57316f0c8f69c663093f/holidays-0.101-py3-none-any.whl", hash = "sha256:be1d5bb0b662d709da08dcdfa9b42feb678312df2a5d6280421da71349e4757f", size = 1542496 },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1681,6 +1693,7 @@ dependencies = [
     { name = "chardet" },
     { name = "finvizfinance" },
     { name = "google-generativeai" },
+    { name = "holidays" },
     { name = "loguru" },
     { name = "lxml" },
     { name = "openpyxl" },
@@ -1713,6 +1726,7 @@ requires-dist = [
     { name = "chardet", specifier = ">=5.2.0,<6.0.0" },
     { name = "finvizfinance", specifier = ">=1.3.0" },
     { name = "google-generativeai", specifier = ">=0.8.6" },
+    { name = "holidays", specifier = ">=0.91" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "lxml", specifier = ">=6.0.2" },
     { name = "openpyxl", specifier = ">=3.1.5" },


### PR DESCRIPTION
## Summary
- apply next-business-day report date only from 18:00 on Korean business days
- always roll weekend and Korean holiday publications to the next business day
- cover 12-hour and 24-hour Korean time strings with regression tests

## Validation
- .....................................                                    [100%]
37 passed in 0.84s