### PR TITLE
fix(meritz): restore server-side scheduled scraping

### DIFF
--- a/config/firms.yaml
+++ b/config/firms.yaml
@@ -333,7 +333,10 @@ firms:
     result_file: meritz_result.json
     config_shape: full_config
     empty_policy: require_non_empty
-    server_list: none
+    # GA workflow is dispatch-only because GitHub-hosted IPs are blocked.
+    # Keep this in the regular server set: firm_id=20 has ga_enabled_yn='N',
+    # so the full-scrape GA fallback deliberately filters it out.
+    server_list: async
     ga_full_scrape_list: async
     ga_fallback_excluded: false
     ga_fallback_exclusion_reason: ~
@@ -341,7 +344,7 @@ firms:
     enricher: null
     enrichment_skip: false
     special_funcs: null
-    notes: "GA async + server full-scrape fallback. GA IP 차단으로 schedule 제거(2026-06-23), workflow_dispatch 수동 실행만 유지. _runner.py 정규 패턴."
+    notes: "GA IP 차단으로 schedule 제거(2026-06-23), workflow_dispatch 수동 실행만 유지. server_list=async로 운영 서버가 정기 수집한다; ga_enabled_yn='N'이면 full-scrape GA fallback에서 제외된다. _runner.py 정규 패턴."
 
   hanwha:
     display_name: 한화투자증권

--- a/tests/test_registry_consistency.py
+++ b/tests/test_registry_consistency.py
@@ -49,6 +49,7 @@ class TestScraperFunctionLists:
             "Koreainvestment_selenium_checkNewArticle",
             "Daeshin_checkNewArticle",
             "HANA_checkNewArticle",
+            "MERITZ_checkNewArticle",
         }
         assert names == expected
 
@@ -107,6 +108,7 @@ class TestRegistryConsistency:
             "Koreainvestment_selenium_checkNewArticle",
             "Daeshin_checkNewArticle",
             "HANA_checkNewArticle",
+            "MERITZ_checkNewArticle",
         }
 
     def test_all_29_functions_importable(self):


### PR DESCRIPTION
메리츠증권이 2026-07-08 이후 수집되지 않은 원인을 수정합니다.

- `ga_enabled_yn=N`으로 full-scrape fallback에서 제외되는 메리츠를 운영 서버의 async 정기 수집 목록에 복구
- registry 회귀 테스트로 메리츠 정기 실행을 고정

검증: `DB_BACKEND=static uv run pytest tests/test_registry_consistency.py tests/test_meritz_core.py tests/test_scraper_imports.py -q` (71 passed), `bash scripts/verify_dockerfile.sh`, `bash scripts/verify_standalones.sh`