### PR TITLE
perf(meritz): skip stale detail fetches for backfills

### DIFF
--- a/scrapers/meritz_core.py
+++ b/scrapers/meritz_core.py
@@ -49,6 +49,7 @@ def scrape_meritz(cfg: dict) -> list[dict]:
     cfg.setdefault("firm_id", 20)
     cfg.setdefault("firm_nm", "메리츠증권")
     cfg.setdefault("detail_sel", "a[href$='.pdf']")  # 2026.06: .fileArea 사라짐, a에 직접 PDF href
+    min_report_date = re.sub(r"[^0-9]", "", str(cfg.get("min_report_date", "")))
     requests.packages.urllib3.disable_warnings()
     hdr = {"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"}
     result = []
@@ -74,6 +75,10 @@ def scrape_meritz(cfg: dict) -> list[dict]:
                     source_url = urljoin(cfg["base_url"], link["href"])
                     dc = "작성일" if "작성일" in hmap else "작성일시"
                     rd = re.sub(r"[-./]","",row.select_one(f'td:nth-child({hmap[dc]+1})').get_text(strip=True))
+                    # Backfills only need the requested window.  Skip stale rows before
+                    # the costly per-report detail/PDF request.
+                    if min_report_date and rd < min_report_date:
+                        continue
                     wc = "작성자" if "작성자" in hmap else "작성자명"
                     writer = row.select_one(f'td:nth-child({hmap[wc]+1})').get_text(strip=True)
                     # detail fetch for PDF (2026.06: a[href$='.pdf'] 직접)

--- a/tests/test_meritz_core.py
+++ b/tests/test_meritz_core.py
@@ -60,6 +60,24 @@ def test_scrape_meritz_sets_pdf_url_from_detail_pdf_link_with_query(monkeypatch)
     assert rows[0]["report_unique_key"] == rows[0]["pdf_file_url"]
 
 
+def test_scrape_meritz_skips_stale_rows_before_detail_request(monkeypatch):
+    calls = []
+
+    def fake_get(url, *args, **kwargs):
+        calls.append(url)
+        return _ListResponse()
+
+    monkeypatch.setattr("scrapers.meritz_core.requests.get", fake_get)
+
+    rows = scrape_meritz({
+        "url": "https://home.imeritz.com/dalyrpt/InfoMain.do?pageNum=1",
+        "min_report_date": "2026-07-10",
+    })
+
+    assert rows == []
+    assert calls == ["https://home.imeritz.com/dalyrpt/InfoMain.do?pageNum=1"]
+
+
 def test_resolve_meritz_pdf_url_from_iframe_srcdoc():
     from scrapers.meritz_core import _resolve_meritz_pdf_url
 


### PR DESCRIPTION
메리츠 백필 시 요청 기간 이전의 목록 행은 PDF 상세 조회 전에 제외합니다.

검증: `DB_BACKEND=static uv run pytest tests/test_meritz_core.py tests/test_registry_consistency.py tests/test_scraper_imports.py -q` (72 passed).