### PR TITLE
chore: ignore transient iM scraper log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,6 +166,7 @@ token.*
 *.db
 *.*Zone.Identifier
 error_response.txt
+imfn_log.txt
 .env.bak
 .codex
 .codex/


### PR DESCRIPTION
Remove an empty stray file and transient iM collection log; prevent the log from being reintroduced.