### PR TITLE
fix: classify overseas reports at ingestion boundary

### DIFF
--- a/models/market_classification.py
+++ b/models/market_classification.py
@@ -1,0 +1,63 @@
+"""Shared market classification at the scraper-to-database boundary.
+
+Source adapters may provide a market value when their source board is
+authoritative.  This module keeps those declarations, but corrects them when
+the title itself contains stronger domestic or overseas ticker evidence.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+# Hana's configured URL list is positional.  These source-board positions are
+# the broker's dedicated overseas boards: global strategy, global industry,
+# and global company research.  Keep this small and explicit rather than
+# treating a generic Korean keyword as overseas coverage.
+SOURCE_GLOBAL_BOARDS: dict[int, frozenset[int]] = {
+    3: frozenset({14, 15, 16}),
+}
+
+# A domestic ticker is decisive even when a source board is normally global.
+_DOMESTIC_TICKER_RE = re.compile(r"\([^)]*\.\s*K[QS](?:[^A-Z]|$)", re.IGNORECASE)
+
+# Two-letter exchange suffixes observed in report titles.  KOSPI/KOSDAQ
+# (.KS/.KQ) are deliberately excluded and handled by _DOMESTIC_TICKER_RE.
+_FOREIGN_TICKER_RE = re.compile(
+    r"\([^)]*\.\s*(?:US|JP|HK|CH|CN|TW|FP|GR|LN|NA|SW|AU|IN|SP|SS|ID)(?:[^A-Z]|$)",
+    re.IGNORECASE,
+)
+
+
+def classify_market_type(
+    *,
+    firm_id: Any,
+    board_id: Any,
+    article_title: Any,
+    declared_market_type: Any,
+) -> str:
+    """Return the canonical market type for a scraper payload.
+
+    Evidence priority is: domestic ticker > foreign ticker > dedicated source
+    board > scraper declaration/default.  A declaration such as ``US`` or
+    ``JP`` is retained; inferred overseas rows use ``GLOBAL``.
+    """
+    declared = str(declared_market_type or "KR").strip().upper() or "KR"
+    title = str(article_title or "")
+
+    if _DOMESTIC_TICKER_RE.search(title):
+        return "KR"
+    if _FOREIGN_TICKER_RE.search(title):
+        return declared if declared != "KR" else "GLOBAL"
+
+    try:
+        is_dedicated_global_board = int(board_id) in SOURCE_GLOBAL_BOARDS.get(
+            int(firm_id), frozenset()
+        )
+    except (TypeError, ValueError):
+        is_dedicated_global_board = False
+    if is_dedicated_global_board:
+        return "GLOBAL"
+
+    return declared

--- a/models/report_payload.py
+++ b/models/report_payload.py
@@ -7,6 +7,8 @@ from datetime import datetime, timezone
 import re
 from typing import Any, Mapping
 
+from models.market_classification import classify_market_type
+
 
 class ReportPayloadError(ValueError):
     """Raised when scraper output cannot satisfy the shared report contract."""
@@ -76,7 +78,12 @@ class ReportPayload:
             telegram_url=telegram_url,
             pdf_file_url=pdf_file_url,
             writer=str(item.get("writer") or ""),
-            mkt_tp=str(item.get("mkt_tp") or "KR"),
+            mkt_tp=classify_market_type(
+                firm_id=item.get("firm_id"),
+                board_id=item.get("board_id"),
+                article_title=item.get("article_title"),
+                declared_market_type=item.get("mkt_tp"),
+            ),
             report_unique_key=unique_key,
             save_at=save_at,
             article_text=str(item.get("article_text") or "").strip(),

--- a/scrapers/hana_core.py
+++ b/scrapers/hana_core.py
@@ -5,6 +5,8 @@ from datetime import datetime, timezone, timedelta
 from bs4 import BeautifulSoup
 import holidays
 
+from models.market_classification import classify_market_type
+
 def _adjust_date(report_date, time_str):
     """Apply Hana's KST reporting-date cutover on the source publication date.
 
@@ -99,7 +101,17 @@ def scrape_hana(cfg: dict) -> list[dict]:
                     writer = writers[i].get_text(strip=True) if i < len(writers) else ""
                     ts = times[i].get_text(strip=True) if i < len(times) else ""
                     article_text = contns[i].get_text(strip=True) if i < len(contns) else ""
-                    mkt = "GLOBAL" if board_order in cfg.get("global_boards",[]) else "KR"
+                    # Preserve an explicit deployment override, while the
+                    # shared classifier supplies the canonical dedicated
+                    # overseas-board mapping when production config is only a
+                    # positional URL list.
+                    declared_mkt = "GLOBAL" if board_order in cfg.get("global_boards", []) else "KR"
+                    mkt = classify_market_type(
+                        firm_id=cfg["firm_id"],
+                        board_id=board_order,
+                        article_title=title,
+                        declared_market_type=declared_mkt,
+                    )
                     result.append(dict(firm_id=cfg["firm_id"],board_id=board_order,
                         firm_nm=cfg["firm_nm"],report_date=_adjust_date(rd,ts),
                         telegram_url=dl,pdf_file_url=dl,article_title=title,writer=writer,

--- a/sql/backfill_global_market_type.sql
+++ b/sql/backfill_global_market_type.sql
@@ -1,0 +1,29 @@
+-- One-time repair for rows written before shared market classification.
+--
+-- Evidence priority matches models/market_classification.py:
+--   1. A domestic .KS/.KQ ticker is never changed.
+--   2. A recognised overseas exchange suffix is GLOBAL.
+--   3. Hana's dedicated overseas boards (14/15/16) are GLOBAL.
+--
+-- Safe to rerun: only KR rows are candidates, and the UPDATE changes them to
+-- GLOBAL. Run through the production PostgreSQL wrapper, then invalidate the
+-- external API cache.
+BEGIN;
+
+WITH corrected AS (
+    UPDATE tbl_sec_reports AS r
+    SET mkt_tp = 'GLOBAL'
+    WHERE r.mkt_tp = 'KR'
+      AND r.article_title !~* '[(][^)]*[.]K[QS]([^A-Z]|$)'
+      AND (
+          (r.firm_id = 3 AND r.board_id IN (14, 15, 16))
+          OR r.article_title ~* '[(][^)]*[.](US|JP|HK|CH|CN|TW|FP|GR|LN|NA|SW|AU|IN|SP|SS|ID)([^A-Z]|$)'
+      )
+    RETURNING r.firm_id, r.board_id
+)
+SELECT firm_id, board_id, COUNT(*) AS corrected_count
+FROM corrected
+GROUP BY firm_id, board_id
+ORDER BY corrected_count DESC, firm_id, board_id;
+
+COMMIT;

--- a/tests/test_report_payload_contract.py
+++ b/tests/test_report_payload_contract.py
@@ -50,6 +50,33 @@ def test_legacy_save_time_is_an_explicit_artifact_adapter():
 
 
 @pytest.mark.parametrize(
+    "firm_id,board_id,title,declared,expected",
+    [
+        (3, 16, "AMD(AMD.US): FY 2Q26 Review", "KR", "GLOBAL"),
+        (3, 15, "글로벌 산업 전망", "KR", "GLOBAL"),
+        (3, 16, "삼성전자(005930.KS): 실적 점검", "GLOBAL", "KR"),
+        (10, 3, "NVIDIA(NVDA.US): earnings", "KR", "GLOBAL"),
+        (10, 3, "삼성전자(005930.KS): earnings", "US", "KR"),
+        (1, 0, "국내 산업 전망", "KR", "KR"),
+    ],
+)
+def test_market_type_is_classified_at_the_shared_payload_boundary(
+    firm_id, board_id, title, declared, expected
+):
+    payload = ReportPayload.from_scraper({
+        "firm_id": firm_id,
+        "board_id": board_id,
+        "firm_nm": "test",
+        "report_date": "20260806",
+        "article_title": title,
+        "report_unique_key": f"key-{firm_id}-{board_id}-{title}",
+        "mkt_tp": declared,
+    })
+
+    assert payload.mkt_tp == expected
+
+
+@pytest.mark.parametrize(
     "item,message",
     [
         ({"report_date": "20260710", "firm_nm": "Firm"}, "missing report_unique_key"),


### PR DESCRIPTION
## What\n- classify market type at the shared scraper-to-DB payload boundary\n- repair Hana dedicated global boards (14/15/16) and title-level overseas tickers\n- add an idempotent, audited historical backfill SQL\n\n## Evidence\n- production backfill corrected the explicit scope and cache was invalidated\n- uv run pytest tests/test_report_payload_contract.py tests/test_hana_core.py -q passed (17) in clean origin/main worktree\n- bash scripts/verify_dockerfile.sh passed\n\n## Note\nThe protected main branch requires the test status check before merge.