### PR TITLE
fix: classify all dedicated overseas report boards

### DIFF
--- a/models/market_classification.py
+++ b/models/market_classification.py
@@ -11,12 +11,21 @@ import re
 from typing import Any
 
 
-# Hana's configured URL list is positional.  These source-board positions are
-# the broker's dedicated overseas boards: global strategy, global industry,
-# and global company research.  Keep this small and explicit rather than
-# treating a generic Korean keyword as overseas coverage.
+# These are dedicated overseas source boards confirmed from the production
+# board catalog.  Positional Hana board IDs come from the broker URL list;
+# other IDs are the canonical broker board IDs persisted with each row.  Keep
+# this explicit rather than classifying broad strategy/industry boards from a
+# Korean keyword in their titles.
 SOURCE_GLOBAL_BOARDS: dict[int, frozenset[int]] = {
-    3: frozenset({14, 15, 16}),
+    0: frozenset({9}),             # LS: 해외리서치
+    1: frozenset({3, 5}),          # 신한: 해외주식, 해외 채권
+    3: frozenset({14, 15, 16}),    # 하나: 글로벌 투자/산업/기업분석
+    4: frozenset({7, 11}),         # KB: Global Insights, Asia Headline
+    5: frozenset({2}),             # 삼성: 해외 분석
+    9: frozenset({2}),             # 현대차: 해외주식
+    10: frozenset({3}),            # 키움: 미국/선진국
+    18: frozenset({2}),            # IM: 기업분석(해외)
+    25: frozenset({4, 5}),         # IBK: 해외기업분석, 글로벌ETF
 }
 
 # A domestic ticker is decisive even when a source board is normally global.
@@ -39,17 +48,12 @@ def classify_market_type(
 ) -> str:
     """Return the canonical market type for a scraper payload.
 
-    Evidence priority is: domestic ticker > foreign ticker > dedicated source
-    board > scraper declaration/default.  A declaration such as ``US`` or
+    Evidence priority is: dedicated source board > domestic ticker > foreign
+    ticker > scraper declaration/default.  A declaration such as ``US`` or
     ``JP`` is retained; inferred overseas rows use ``GLOBAL``.
     """
     declared = str(declared_market_type or "KR").strip().upper() or "KR"
     title = str(article_title or "")
-
-    if _DOMESTIC_TICKER_RE.search(title):
-        return "KR"
-    if _FOREIGN_TICKER_RE.search(title):
-        return declared if declared != "KR" else "GLOBAL"
 
     try:
         is_dedicated_global_board = int(board_id) in SOURCE_GLOBAL_BOARDS.get(
@@ -59,5 +63,10 @@ def classify_market_type(
         is_dedicated_global_board = False
     if is_dedicated_global_board:
         return "GLOBAL"
+
+    if _DOMESTIC_TICKER_RE.search(title):
+        return "KR"
+    if _FOREIGN_TICKER_RE.search(title):
+        return declared if declared != "KR" else "GLOBAL"
 
     return declared

--- a/sql/backfill_global_market_type.sql
+++ b/sql/backfill_global_market_type.sql
@@ -1,9 +1,10 @@
 -- One-time repair for rows written before shared market classification.
 --
 -- Evidence priority matches models/market_classification.py:
---   1. A domestic .KS/.KQ ticker is never changed.
---   2. A recognised overseas exchange suffix is GLOBAL.
---   3. Hana's dedicated overseas boards (14/15/16) are GLOBAL.
+--   1. A dedicated overseas source board is GLOBAL, including a domestic
+--      ticker mentioned for comparison in its title.
+--   2. Else a recognised overseas exchange suffix is GLOBAL.
+--   3. A .KS/.KQ ticker blocks only title-based inference.
 --
 -- Safe to rerun: only KR rows are candidates, and the UPDATE changes them to
 -- GLOBAL. Run through the production PostgreSQL wrapper, then invalidate the
@@ -14,10 +15,22 @@ WITH corrected AS (
     UPDATE tbl_sec_reports AS r
     SET mkt_tp = 'GLOBAL'
     WHERE r.mkt_tp = 'KR'
-      AND r.article_title !~* '[(][^)]*[.]K[QS]([^A-Z]|$)'
       AND (
-          (r.firm_id = 3 AND r.board_id IN (14, 15, 16))
-          OR r.article_title ~* '[(][^)]*[.](US|JP|HK|CH|CN|TW|FP|GR|LN|NA|SW|AU|IN|SP|SS|ID)([^A-Z]|$)'
+          (r.firm_id, r.board_id) IN (
+              (0, 9),
+              (1, 3), (1, 5),
+              (3, 14), (3, 15), (3, 16),
+              (4, 7), (4, 11),
+              (5, 2),
+              (9, 2),
+              (10, 3),
+              (18, 2),
+              (25, 4), (25, 5)
+          )
+          OR (
+              r.article_title !~* '[(][^)]*[.]K[QS]([^A-Z]|$)'
+              AND r.article_title ~* '[(][^)]*[.](US|JP|HK|CH|CN|TW|FP|GR|LN|NA|SW|AU|IN|SP|SS|ID)([^A-Z]|$)'
+          )
       )
     RETURNING r.firm_id, r.board_id
 )

--- a/tests/test_report_payload_contract.py
+++ b/tests/test_report_payload_contract.py
@@ -54,10 +54,11 @@ def test_legacy_save_time_is_an_explicit_artifact_adapter():
     [
         (3, 16, "AMD(AMD.US): FY 2Q26 Review", "KR", "GLOBAL"),
         (3, 15, "글로벌 산업 전망", "KR", "GLOBAL"),
-        (3, 16, "삼성전자(005930.KS): 실적 점검", "GLOBAL", "KR"),
+        (3, 16, "삼성전자(005930.KS): 해외 경쟁사 비교", "KR", "GLOBAL"),
         (10, 3, "NVIDIA(NVDA.US): earnings", "KR", "GLOBAL"),
-        (10, 3, "삼성전자(005930.KS): earnings", "US", "KR"),
+        (10, 3, "삼성전자(005930.KS): earnings", "US", "GLOBAL"),
         (1, 0, "국내 산업 전망", "KR", "KR"),
+        (1, 3, "해외주식 주간전략", "KR", "GLOBAL"),
     ],
 )
 def test_market_type_is_classified_at_the_shared_payload_boundary(


### PR DESCRIPTION
## Scope\n- extend the shared market classifier to every production board catalogued as dedicated overseas/global coverage\n- make source-board identity outrank a domestic ticker mentioned for comparison\n- expand the idempotent historical backfill to the same source-of-truth map\n\n## Production audit\n- 3,821 remaining KR rows were found on explicit overseas boards before this correction\n- the initial SQL pass exposed active old-image upserts, so final backfill follows deployment of this shared boundary\n\n## Verification\n- uv run pytest tests/test_report_payload_contract.py tests/test_hana_core.py -q (18 passed)\n- bash scripts/verify_dockerfile.sh passed