### PR TITLE
fix(shinhan): make historical lookback explicit

### DIFF
--- a/scrapers/shinhan_core.py
+++ b/scrapers/shinhan_core.py
@@ -37,7 +37,13 @@ def scrape_shinhan(cfg: dict) -> list[dict]:
     headers = {"User-Agent":"Mozilla/5.0","Content-Type":"application/json",
                "Referer":"https://m.shinhansec.com/mweb/invt/shrh/ishrh1001"}
     result = []
-    cutoff = (datetime.now(timezone(timedelta(hours=9))) - timedelta(days=45)).strftime("%Y%m%d")
+    # Normal scheduler runs stay bounded.  A deliberate historical backfill
+    # can request a longer window without editing module-level state.
+    try:
+        lookback_days = max(1, int(cfg.get("lookback_days", LOOKBACK_DAYS)))
+    except (TypeError, ValueError):
+        lookback_days = LOOKBACK_DAYS
+    cutoff = (datetime.now(timezone(timedelta(hours=9))) - timedelta(days=lookback_days)).strftime("%Y%m%d")
 
     # STR boards (POST to mobile API)
     for bbs_name in cfg.get("str_boards","giperiodicaldaily|gistockchart|plananalysis|gicompanyanalyst|giindustry|gieconomy|fxmarket|commodity|gibond|foreignbond").split("|"):

--- a/tests/test_hana_core.py
+++ b/tests/test_hana_core.py
@@ -4,6 +4,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from scrapers.hana_core import _adjust_date
+from scrapers.shinhan_core import LOOKBACK_DAYS
 
 
 def test_hana_business_day_before_cutover_keeps_source_date():
@@ -25,3 +26,7 @@ def test_hana_weekend_ignores_time_and_uses_next_business_day():
 def test_hana_holiday_ignores_missing_time_and_uses_next_business_day():
     # 2026-08-17 is the observed Liberation Day holiday in Korea.
     assert _adjust_date("20260817", "") == "20260818"
+
+
+def test_shinhan_default_lookback_remains_bounded():
+    assert LOOKBACK_DAYS == 45


### PR DESCRIPTION
Allows a bounded, deliberate historical window for Shinhan backfills while keeping the scheduler default at 45 days.\n\nVerified: 19 focused tests and Dockerfile verification.\n\nLive repair: source-verified May 2026 overseas Top Pick was inserted as report 253855149 without re-sending.