### PR TITLE
fix: bound LS WARP outage retries

### DIFF
--- a/modules/Daeshin_17.py
+++ b/modules/Daeshin_17.py
@@ -137,8 +137,15 @@ async def Daeshin_checkNewArticle():
                 tasks.append(fetch_page_data(session, page, viewstate, viewstate_gen, event_validation, sem))
             
             await asyncio.gather(*tasks)
+        except asyncio.TimeoutError:
+            # The source occasionally stalls from the production IP.  This is
+            # an empty-result, retry-on-next-schedule condition, not a scraper
+            # crash that should trigger a watchdog error alert.
+            logger.warning("Daeshin scraping timed out; retrying on the next schedule.")
         except Exception as e:
-            logger.error(f"Error during Daeshin scraping process: {e}")
+            logger.error(
+                f"Error during Daeshin scraping process: {type(e).__name__}: {e!r}"
+            )
             
         return json_data_list
 

--- a/modules/LS_0.py
+++ b/modules/LS_0.py
@@ -28,6 +28,9 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 skip_boards = set()
 USE_WARP_ONLY = False  # 직접 접속 실패 시 전역적으로 WARP만 사용하도록 설정
+# A failed SOCKS/WARP tunnel affects every LS board in the same run.  Do not
+# spend the scheduler's entire job budget retrying identical requests.
+WARP_UNAVAILABLE = False
 
 # 프록시 설정 (환경 변수가 없으면 로컬 기본값 사용)
 SOCKS_PROXY = os.getenv("SOCKS_PROXY_URL", "socks5h://localhost:9091")
@@ -61,7 +64,7 @@ def _article_unique_key(article: dict) -> str:
     return str(article.get("report_unique_key") or article.get("source_url") or "")
 
 def get_soup_with_warp(url, headers):
-    global USE_WARP_ONLY
+    global USE_WARP_ONLY, WARP_UNAVAILABLE
     for attempt in range(1, LS_WARP_RETRIES + 1):
         try:
             response = requests.get(url, headers=headers, proxies=PROXIES, verify=False, timeout=50)
@@ -72,6 +75,7 @@ def get_soup_with_warp(url, headers):
                 time.sleep(attempt * 5)
             else:
                 logger.error(f"LS WARP 최종 실패 (시도 {attempt}/{LS_WARP_RETRIES}): {url} ({e})")
+                WARP_UNAVAILABLE = True
                 return None
 
 def LS_checkNewArticle(page=1, is_imported=False, skip_boards=None, max_pages=2):
@@ -79,7 +83,8 @@ def LS_checkNewArticle(page=1, is_imported=False, skip_boards=None, max_pages=2)
 
     max_pages: 스크래핑할 페이지 수 (기본 2페이지까지 긁음)
     """
-    global USE_WARP_ONLY
+    global USE_WARP_ONLY, WARP_UNAVAILABLE
+    WARP_UNAVAILABLE = False
     firm_id = 0
     json_data_list = []
     requests.packages.urllib3.disable_warnings()
@@ -161,6 +166,11 @@ def LS_checkNewArticle(page=1, is_imported=False, skip_boards=None, max_pages=2)
                     soupList = soup.select('#contents > table > tbody > tr')
                 else:
                     skip_boards.add(board_id)
+                    if WARP_UNAVAILABLE:
+                        logger.warning(
+                            "LS WARP tunnel is unavailable; skipping remaining LS boards for this run."
+                        )
+                        break
 
             logger.info(f"{firm_info.get_firm_name()}의 {firm_info.get_board_name()} 게시판 p.{p}... (Found {len(soupList)} articles)")
 

--- a/tests/test_watchdog_external_failure_budget.py
+++ b/tests/test_watchdog_external_failure_budget.py
@@ -1,0 +1,21 @@
+import requests
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules import LS_0
+
+
+def test_ls_marks_warp_unavailable_after_retry_budget(monkeypatch):
+    monkeypatch.setattr(LS_0, "LS_WARP_RETRIES", 2)
+    monkeypatch.setattr(LS_0.time, "sleep", lambda _: None)
+    monkeypatch.setattr(LS_0, "WARP_UNAVAILABLE", False)
+
+    def unavailable(*args, **kwargs):
+        raise requests.ConnectionError("WARP tunnel unavailable")
+
+    monkeypatch.setattr(LS_0.requests, "get", unavailable)
+
+    assert LS_0.get_soup_with_warp("https://example.test/board", {}) is None
+    assert LS_0.WARP_UNAVAILABLE is True


### PR DESCRIPTION
## Incident\n- 2026-08-08 KST: an unavailable LS WARP tunnel exhausted retries across boards and the scheduler killed the scraper after 900s.\n- Daeshin's transient timeout had no useful exception type and was emitted as an error.\n\n## Fix\n- Stop the remaining LS boards after the WARP retry budget is exhausted for a run.\n- Treat Daeshin timeouts as retry-on-next-schedule warnings and retain exception type for real failures.\n- Add a regression test for WARP outage state.\n\n## Verification\n- ==> Offline manifest and runtime file guards
OK
==> Deterministic unit and contract regression suite
============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0 -- /home/ubuntu/workspace/external.reports-hub/apps/scrapers/ssh-reports-scraper-watchdog-fix/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /home/ubuntu/workspace/external.reports-hub/apps/scrapers/ssh-reports-scraper-watchdog-fix
configfile: pyproject.toml
testpaths: tests
plugins: anyio-4.13.0, asyncio-1.4.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 362 items

tests/test_article_text.py::test_extract_ds_summary_strips_markup_and_entities PASSED [  0%]
tests/test_article_text.py::test_extract_ds_summary_returns_empty_for_missing_or_short_body PASSED [  0%]
tests/test_article_text.py::test_extract_ds_summary_is_bounded PASSED    [  0%]
tests/test_article_text.py::test_fetches_detail_only_for_new_ds_rows PASSED [  1%]
tests/test_config_manager.py::test_get_urls_allows_missing_config_source <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_config_manager.py PASSED [  1%]
tests/test_config_manager.py::test_get_urls_raises_when_loaded_urls_missing_key <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_config_manager.py PASSED [  1%]
tests/test_config_manager.py::test_get_urls_uses_default_for_optional_lookup <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_config_manager.py PASSED [  1%]
tests/test_config_manager.py::test_env_defaults_to_production <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_config_manager.py PASSED [  2%]
tests/test_config_manager.py::test_env_resolves_dev <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_config_manager.py PASSED [  2%]
tests/test_config_manager.py::test_env_resolves_production <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_config_manager.py PASSED [  2%]
tests/test_config_manager.py::test_get_secret_prefers_selected_environment_over_common <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_config_manager.py PASSED [  3%]
tests/test_config_manager.py::test_get_secret_process_environment_overrides_file <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_config_manager.py PASSED [  3%]
tests/test_config_manager.py::test_get_secret_missing_returns_default <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_config_manager.py PASSED [  3%]
tests/test_config_manager.py::test_fallback_to_legacy_prod_section <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_config_manager.py PASSED [  3%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_list[ds_core.py] PASSED [  4%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_list[ibk_core.py] PASSED [  4%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_list[toss_core.py] PASSED [  4%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_list[imfn_core.py] PASSED [  4%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_list[daol_core.py] PASSED [  5%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_list[kyobo_core.py] PASSED [  5%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_list[sangsangin_core.py] PASSED [  5%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_list[meritz_core.py] PASSED [  6%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_list[hanyang_core.py] PASSED [  6%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_list[dbfi_core.py] PASSED [  6%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_list[samsung_core.py] PASSED [  6%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_list[heungkuk_core.py] PASSED [  7%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_list[hanwha_core.py] PASSED [  7%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_list[kiwoom_core.py] PASSED [  7%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_list[hmsec_core.py] PASSED [  8%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_list[shinyoung_core.py] PASSED [  8%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_list[hana_core.py] PASSED [  8%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_list[miraeasset_core.py] PASSED [  8%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_list[shinhan_core.py] PASSED [  9%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_list[yuanta_core.py] PASSED [  9%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_list[eugene_core.py] PASSED [  9%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_list[leading_core.py] PASSED [  9%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_str[ds_core.py] PASSED [ 10%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_str[ibk_core.py] PASSED [ 10%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_str[toss_core.py] PASSED [ 10%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_str[imfn_core.py] PASSED [ 11%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_str[daol_core.py] PASSED [ 11%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_str[kyobo_core.py] PASSED [ 11%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_str[sangsangin_core.py] PASSED [ 11%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_str[meritz_core.py] PASSED [ 12%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_str[hanyang_core.py] PASSED [ 12%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_str[dbfi_core.py] PASSED [ 12%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_str[samsung_core.py] PASSED [ 12%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_str[heungkuk_core.py] PASSED [ 13%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_str[hanwha_core.py] PASSED [ 13%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_str[kiwoom_core.py] PASSED [ 13%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_str[hmsec_core.py] PASSED [ 14%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_str[shinyoung_core.py] PASSED [ 14%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_str[hana_core.py] PASSED [ 14%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_str[miraeasset_core.py] PASSED [ 14%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_str[shinhan_core.py] PASSED [ 15%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_str[yuanta_core.py] PASSED [ 15%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_str[eugene_core.py] PASSED [ 15%]
tests/test_core_contract.py::TestCoreBackwardCompat::test_core_accepts_str[leading_core.py] PASSED [ 16%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[leading.py] PASSED [ 16%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[kb.py] PASSED [ 16%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[dbfi.py] PASSED [ 16%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[daol.py] PASSED [ 17%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[samsung.py] PASSED [ 17%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[toss.py] PASSED [ 17%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[daeshin.py] PASSED [ 17%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[hana.py] PASSED [ 18%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[meritz.py] PASSED [ 18%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[ds.py] PASSED [ 18%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[ibk.py] PASSED [ 19%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[imfn.py] PASSED [ 19%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[ls.py] PASSED [ 19%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[hanwha.py] PASSED [ 19%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[hanyang.py] PASSED [ 20%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[kiwoom.py] PASSED [ 20%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[ls_v2.py] PASSED [ 20%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[shinhan.py] PASSED [ 20%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[nhqv.py] PASSED [ 21%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[sks.py] PASSED [ 21%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[shinyoung.py] PASSED [ 21%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[koreainvestment.py] PASSED [ 22%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[sangsanginib.py] PASSED [ 22%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[hmsec.py] PASSED [ 22%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[kyobo.py] PASSED [ 22%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[miraeasset.py] PASSED [ 23%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[yuanta.py] PASSED [ 23%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[heungkuk.py] PASSED [ 23%]
tests/test_core_contract.py::TestStandaloneSyntax::test_standalone_compiles[_runner.py] PASSED [ 24%]
tests/test_core_contract.py::TestValidation::test_valid_result_passes PASSED [ 24%]
tests/test_core_contract.py::TestValidation::test_empty_report_date_filtered PASSED [ 24%]
tests/test_core_contract.py::TestValidation::test_invalid_report_date_filtered PASSED [ 24%]
tests/test_core_contract.py::TestValidation::test_missing_key_filtered PASSED [ 25%]
tests/test_core_contract.py::TestValidation::test_today_date_not_substituted PASSED [ 25%]
tests/test_daol_core.py::test_scrape_daol_defaults_canonical_firm_fields PASSED [ 25%]
tests/test_db_factory.py::test_get_db_default_uses_sec_reports_manager <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_db_factory.py PASSED [ 25%]
tests/test_db_factory.py::test_get_db_ssh_library_backend <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_db_factory.py PASSED [ 26%]
tests/test_db_factory.py::test_get_db_postgres_backend_uses_scraper_sec_reports_manager <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_db_factory.py PASSED [ 26%]
tests/test_dbfi_core.py::test_scrape_dbfi_accepts_legacy_rdt_item_key PASSED [ 26%]
tests/test_dbfi_detail.py::TestDbfiDetailNaming::test_new_name_exists_and_callable PASSED [ 27%]
tests/test_dbfi_detail.py::TestDbfiDetailNaming::test_old_name_is_alias PASSED [ 27%]
tests/test_dbfi_detail.py::TestDbfiDetailNaming::test_import_old_name_still_works PASSED [ 27%]
tests/test_dbfi_detail.py::TestDbfiDetailNaming::test_import_new_name_works PASSED [ 27%]
tests/test_dbfi_detail.py::TestDbfiDetailNaming::test_empty_articles_returns_empty PASSED [ 28%]
tests/test_dbfi_detail.py::TestDbfiDetailNaming::test_old_name_empty_articles_returns_empty PASSED [ 28%]
tests/test_dbfi_detail.py::TestDbfiDetailNaming::test_dbfi_enrich_exists_and_callable PASSED [ 28%]
tests/test_dbfi_detail.py::TestDbfiDetailNaming::test_ls_enrich_exists_and_callable PASSED [ 29%]
tests/test_dbfi_detail.py::TestDbfiDetailNaming::test_dbfi_enrich_uses_parameterized_backlog_query PASSED [ 29%]
tests/test_dbfi_detail.py::TestDbfiDetailNaming::test_ls_enrich_updates_resolved_urls_and_parameterizes_queries PASSED [ 29%]
tests/test_dbfi_post_error_context.py::test_dbfi_post_failure_logs_type_not_private_text PASSED [ 29%]
tests/test_dockerfile_copy.py::test_dockerfile_copies_runtime_manifest_config PASSED [ 30%]
tests/test_dockerfile_copy.py::test_dockerfile_copies_all_runtime_source_directories PASSED [ 30%]
tests/test_firm_info.py::TestFirmInfoGaEnabled::test_ga_enabled_false_in_static_fallback PASSED [ 30%]
tests/test_firm_info.py::TestFirmInfoGaEnabled::test_ga_enabled_in_get_state PASSED [ 30%]
tests/test_firm_info.py::TestFirmInfoGaEnabled::test_ga_enabled_persists_after_set_firm_id PASSED [ 31%]
tests/test_firm_info.py::TestFirmInfoGaEnabled::test_iter_active_firm_ids_preserves_database_gaps PASSED [ 31%]
tests/test_firm_info.py::TestFirmUtilsGaEnabled::test_ga_enabled_returns_bool PASSED [ 31%]
tests/test_firm_info.py::TestFirmUtilsGaEnabled::test_ga_enabled_importable PASSED [ 32%]
tests/test_firm_info.py::TestFirmInfoStaticFallbackGraceful::test_static_fallback_sets_ga_enabled_false PASSED [ 32%]
tests/test_firm_info.py::TestFirmInfoPostgresGaEnabled::test_postgres_loads_ga_enabled_yn PASSED [ 32%]
tests/test_firm_info.py::TestFirmInfoPostgresGaEnabled::test_postgres_ga_enabled_via_firm_utils PASSED [ 32%]
tests/test_firm_info.py::TestGaEnabledOrders::test_returns_none_for_static_fallback PASSED [ 33%]
tests/test_firm_info.py::TestGaEnabledOrders::test_returns_none_for_static_backend PASSED [ 33%]
tests/test_firm_info.py::TestGaEnabledOrders::test_returns_enabled_set_for_postgres PASSED [ 33%]
tests/test_firm_manifest.py::test_manifest_parses PASSED                 [ 33%]
tests/test_firm_manifest.py::test_each_firm_has_required_fields PASSED   [ 34%]
tests/test_firm_manifest.py::test_mode_enum PASSED                       [ 34%]
tests/test_firm_manifest.py::test_config_shape_enum PASSED               [ 34%]
tests/test_firm_manifest.py::test_empty_policy_enum PASSED               [ 35%]
tests/test_firm_manifest.py::test_firm_id_uniqueness PASSED              [ 35%]
tests/test_firm_manifest.py::test_core_module_files_exist PASSED         [ 35%]
tests/test_firm_manifest.py::test_standalone_files_exist PASSED          [ 35%]
tests/test_firm_manifest.py::test_server_module_files_exist PASSED       [ 36%]
tests/test_firm_manifest.py::test_workflow_files_exist PASSED            [ 36%]
tests/test_firm_manifest.py::test_env_var_consistency PASSED             [ 36%]
tests/test_firm_manifest.py::test_result_file_in_workflow PASSED         [ 37%]
tests/test_ga_enabled_error_context.py::test_filter_ga_enabled_logs_exception_preserves_fallback PASSED [ 37%]
tests/test_ga_enabled_policy.py::TestFilterGaEnabled::test_filter_includes_ga_enabled_firms PASSED [ 37%]
tests/test_ga_enabled_policy.py::TestFilterGaEnabled::test_filter_excludes_all_when_none_enabled PASSED [ 37%]
tests/test_ga_enabled_policy.py::TestFilterGaEnabled::test_filter_fallback_on_exception PASSED [ 38%]
tests/test_ga_enabled_policy.py::TestFilterGaEnabled::test_filter_handles_empty_mapping PASSED [ 38%]
tests/test_ga_enabled_policy.py::TestGaFirmsMapping::test_ga_firms_are_dicts PASSED [ 38%]
tests/test_ga_enabled_policy.py::TestGaFirmsMapping::test_ga_firms_keys_are_ints PASSED [ 38%]
tests/test_ga_enabled_policy.py::TestGaFirmsMapping::test_ga_firms_values_are_callable PASSED [ 39%]
tests/test_ga_enabled_policy.py::TestGaFirmsMapping::test_ga_firms_no_overlap PASSED [ 39%]
tests/test_ga_enabled_policy.py::TestGaEnabledUtility::test_ga_enabled_false_in_static_env PASSED [ 39%]
tests/test_ga_enabled_policy.py::TestGaEnabledUtility::test_ga_enabled_returns_bool PASSED [ 40%]
tests/test_ga_enabled_policy.py::TestFilterGaEnabledMetadataSource::test_fallback_to_all_when_orders_is_none PASSED [ 40%]
tests/test_ga_enabled_policy.py::TestFilterGaEnabledMetadataSource::test_filter_by_set_when_orders_is_set PASSED [ 40%]
tests/test_ga_enabled_policy.py::TestFilterGaEnabledMetadataSource::test_empty_set_filters_all_out PASSED [ 40%]
tests/test_hana_core.py::test_hana_business_day_before_cutover_keeps_source_date PASSED [ 41%]
tests/test_hana_core.py::test_hana_business_day_at_cutover_uses_next_business_day PASSED [ 41%]
tests/test_hana_core.py::test_hana_friday_after_cutover_skips_weekend PASSED [ 41%]
tests/test_hana_core.py::test_hana_weekend_ignores_time_and_uses_next_business_day PASSED [ 41%]
tests/test_hana_core.py::test_hana_holiday_ignores_missing_time_and_uses_next_business_day PASSED [ 42%]
tests/test_hana_scheduler_path.py::TestHanaServerOnlyPath::test_hana_in_regular_async_functions PASSED [ 42%]
tests/test_hana_scheduler_path.py::TestHanaServerOnlyPath::test_hana_not_in_ga_firms_async PASSED [ 42%]
tests/test_hana_scheduler_path.py::TestHanaServerOnlyPath::test_hana_import_still_works PASSED [ 43%]
tests/test_hanyang_core.py::test_scrape_hanyang_extracts_report_date_from_default_columns PASSED [ 43%]
tests/test_hanyang_core.py::test_scrape_hanyang_falls_back_when_configured_date_cell_is_wrong PASSED [ 43%]
tests/test_harness.py::test_check_manifest_accepts_valid_enums PASSED    [ 43%]
tests/test_harness.py::test_check_manifest_rejects_invalid_mode PASSED   [ 44%]
tests/test_harness.py::test_check_manifest_rejects_invalid_config_shape PASSED [ 44%]
tests/test_harness.py::test_check_files_reports_missing_core PASSED      [ 44%]
tests/test_harness.py::test_main_list_prints_firm_keys PASSED            [ 45%]
tests/test_harness.py::test_main_check_manifest_does_not_touch_files PASSED [ 45%]
tests/test_heungkuk_core.py::TestDuplicatePdfGuard::test_safe_rows_preserved PASSED [ 45%]
tests/test_heungkuk_core.py::TestDuplicatePdfGuard::test_duplicate_pdf_reassigns_losers_to_article_fallback PASSED [ 45%]
tests/test_heungkuk_core.py::TestDuplicatePdfGuard::test_empty_list PASSED [ 46%]
tests/test_heungkuk_core.py::TestDuplicatePdfGuard::test_same_article_same_pdf_kept PASSED [ 46%]
tests/test_heungkuk_core.py::TestDuplicatePdfGuard::test_all_shared_pdf_one_winner_keeps_pdf PASSED [ 46%]
tests/test_heungkuk_core.py::TestDuplicatePdfGuard::test_none_pdf_handled PASSED [ 46%]
tests/test_heungkuk_core.py::TestHeungkukUniqueKeyPolicy::test_report_unique_key_is_article_url PASSED [ 47%]
tests/test_heungkuk_core.py::TestHeungkukPdfResolution::test_formula_hit_returns_download_url PASSED [ 47%]
tests/test_heungkuk_core.py::TestHeungkukPdfResolution::test_probe_disabled_formula_miss_falls_back PASSED [ 47%]
tests/test_heungkuk_core.py::TestHeungkukPdfResolution::test_probe_enabled_is_bounded PASSED [ 48%]
tests/test_heungkuk_core.py::TestHeungkukPdfFallback::test_unresolved_pdf_uses_article_url_for_telegram_only PASSED [ 48%]
tests/test_kb_parse_error_context.py::test_kb_parse_failure_logs_index_and_continues PASSED [ 48%]
tests/test_legacy_url_config.py::test_url_list_receives_versioned_parser_defaults[Hmsec] PASSED [ 48%]
tests/test_legacy_url_config.py::test_url_list_receives_versioned_parser_defaults[Kiwoom] PASSED [ 49%]
tests/test_legacy_url_config.py::test_url_list_receives_versioned_parser_defaults[Miraeasset] PASSED [ 49%]
tests/test_legacy_url_config.py::test_url_list_receives_versioned_parser_defaults[Samsung] PASSED [ 49%]
tests/test_legacy_url_config.py::test_url_list_receives_versioned_parser_defaults[Toss] PASSED [ 50%]
tests/test_legacy_url_config.py::test_explicit_config_overrides_defaults_without_losing_nested_keys PASSED [ 50%]
tests/test_legacy_url_config.py::test_missing_urls_and_unknown_firm_fail_fast PASSED [ 50%]
tests/test_ls_attachment_resolution.py::test_ls_detail_falls_back_only_after_attachment_is_absent PASSED [ 50%]
tests/test_ls_attachment_resolution.py::test_ls_detail_processes_rows_sequentially PASSED [ 51%]
tests/test_ls_attachment_resolution.py::test_ls_fallback_reloads_latest_db_sequence_for_same_writer PASSED [ 51%]
tests/test_ls_pdf_verifier.py::test_title_matching_accepts_exact_title_with_formatting_noise PASSED [ 51%]
tests/test_ls_pdf_verifier.py::test_title_matching_rejects_a_different_report_with_some_generic_terms PASSED [ 51%]
tests/test_ls_pdf_verifier.py::test_normalize_title_removes_bracketed_author_and_punctuation PASSED [ 52%]
tests/test_meritz_core.py::test_scrape_meritz_sets_pdf_url_from_detail_pdf_link_with_query PASSED [ 52%]
tests/test_meritz_core.py::test_scrape_meritz_skips_stale_rows_before_detail_request PASSED [ 52%]
tests/test_meritz_core.py::test_resolve_meritz_pdf_url_from_iframe_srcdoc PASSED [ 53%]
tests/test_meritz_core.py::test_resolve_meritz_pdf_url_from_download_title PASSED [ 53%]
tests/test_rag_embed_batch.py::test_validate_embedding_response_success PASSED [ 53%]
tests/test_rag_embed_batch.py::test_validate_embedding_response_length_mismatch PASSED [ 53%]
tests/test_rag_embed_batch.py::test_validate_embedding_response_index_out_of_order_sorted PASSED [ 54%]
tests/test_rag_embed_batch.py::test_validate_embedding_response_index_missing PASSED [ 54%]
tests/test_rag_embed_batch.py::test_validate_embedding_response_index_duplicate PASSED [ 54%]
tests/test_rag_embed_batch.py::test_generate_embeddings_raises_on_no_api_key PASSED [ 54%]
tests/test_rag_embed_batch.py::test_validate_gemini_embedding_response_success PASSED [ 55%]
tests/test_rag_embed_batch.py::test_generate_gemini_embeddings_uses_gemini_api_key PASSED [ 55%]
tests/test_rag_embed_batch.py::test_save_embeddings_json_type PASSED     [ 55%]
tests/test_rag_embed_batch.py::test_save_embeddings_vector_type PASSED   [ 56%]
tests/test_rag_embed_batch.py::test_save_embeddings_rollback_on_error PASSED [ 56%]
tests/test_rag_embed_batch.py::test_main_live_run_fail_fast_on_no_api_key PASSED [ 56%]
tests/test_rag_embed_batch.py::test_parse_inserted_date_rejects_conflicting_options PASSED [ 56%]
tests/test_rag_embed_batch.py::test_fetch_reports_can_filter_by_inserted_date PASSED [ 57%]
tests/test_registry_consistency.py::TestScraperFunctionLists::test_regular_sync <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 57%]
tests/test_registry_consistency.py::TestScraperFunctionLists::test_regular_async <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 57%]
tests/test_registry_consistency.py::TestScraperFunctionLists::test_ga_sync_firm_ids <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 58%]
tests/test_registry_consistency.py::TestScraperFunctionLists::test_ga_async_firm_ids <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 58%]
tests/test_registry_consistency.py::TestScraperFunctionLists::test_ga_no_overlap <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 58%]
tests/test_registry_consistency.py::TestScraperFunctionLists::test_all_ga_funcs_callable <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 58%]
tests/test_registry_consistency.py::TestRegistryConsistency::test_29_firms_loaded <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 59%]
tests/test_registry_consistency.py::TestRegistryConsistency::test_firm_ids_0_to_28 <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 59%]
tests/test_registry_consistency.py::TestRegistryConsistency::test_enricher_dispatch <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 59%]
tests/test_registry_consistency.py::TestRegistryConsistency::test_skip_firm_ids <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 59%]
tests/test_registry_consistency.py::TestRegistryConsistency::test_ls_special_functions <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 60%]
tests/test_registry_consistency.py::TestRegistryConsistency::test_regular_sync_from_registry <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 60%]
tests/test_registry_consistency.py::TestRegistryConsistency::test_regular_async_from_registry <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 60%]
tests/test_registry_consistency.py::TestRegistryConsistency::test_all_29_functions_importable <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 61%]
tests/test_registry_consistency.py::TestRegistryConsistency::test_active_callable_modes_match_manifest <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 61%]
tests/test_registry_consistency.py::TestRegistryConsistency::test_active_callable_mode_mismatch_fails <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 61%]
tests/test_registry_consistency.py::TestRegistryConsistency::test_active_missing_callable_fails <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 61%]
tests/test_registry_consistency.py::TestRegistryConsistency::test_missing_entrypoint_contract_fails_with_firm_context[None] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 62%]
tests/test_registry_consistency.py::TestRegistryConsistency::test_missing_entrypoint_contract_fails_with_firm_context[] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 62%]
tests/test_registry_consistency.py::TestRegistryConsistency::test_missing_entrypoint_contract_fails_with_firm_context[   ] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 62%]
tests/test_registry_consistency.py::TestRegistryConsistency::test_entrypoint_contract_does_not_derive_from_module <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 62%]
tests/test_registry_consistency.py::TestYamlStructure::test_all_29_firms_have_func_name <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 63%]
tests/test_registry_consistency.py::TestYamlStructure::test_func_names_unique <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 63%]
tests/test_registry_consistency.py::TestYamlStructure::test_enricher_format_valid <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 63%]
tests/test_registry_consistency.py::TestYamlStructure::test_special_funcs_format_valid <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 64%]
tests/test_registry_consistency.py::TestYamlStructure::test_server_list_values_valid <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 64%]
tests/test_registry_consistency.py::TestYamlStructure::test_ga_full_scrape_list_values_valid <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 64%]
tests/test_registry_consistency.py::TestYamlStructure::test_enricher_consistency <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 64%]
tests/test_registry_consistency.py::TestYamlStructure::test_enrichment_skip_consistency <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 65%]
tests/test_registry_consistency.py::TestYamlStructure::test_special_funcs_aggregated <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 65%]
tests/test_registry_consistency.py::TestYamlStructure::test_special_funcs_importable <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 65%]
tests/test_registry_consistency.py::TestYamlStructure::test_missing_manifest_fails <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 66%]
tests/test_registry_consistency.py::TestYamlStructure::test_malformed_manifest_fails <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 66%]
tests/test_registry_consistency.py::TestYamlStructure::test_duplicate_firm_ids_fail <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 66%]
tests/test_registry_consistency.py::TestScraperHealthUtility::test_empty_rows_no_errors <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 66%]
tests/test_registry_consistency.py::TestScraperHealthUtility::test_non_list_returns_error <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 67%]
tests/test_registry_consistency.py::TestScraperHealthUtility::test_no_report_date_error <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 67%]
tests/test_registry_consistency.py::TestScraperHealthUtility::test_valid_rows_no_errors <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 67%]
tests/test_registry_consistency.py::TestScraperHealthUtility::test_stale_date_returns_errors <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_registry_consistency.py PASSED [ 67%]
tests/test_report_json_store.py::test_format_report_messages_groups_by_firm PASSED [ 68%]
tests/test_report_json_store.py::test_format_legacy_message_matches_json_util_for_single_report PASSED [ 68%]
tests/test_report_json_store.py::test_json_util_format_message_keeps_legacy_single_report_text PASSED [ 68%]
tests/test_report_json_store.py::test_format_legacy_message_matches_json_util_for_report_list PASSED [ 69%]
tests/test_report_json_store.py::test_json_util_format_message_keeps_legacy_list_last_item_behavior PASSED [ 69%]
tests/test_report_json_store.py::test_format_legacy_message_chunks_matches_json_util_chunk_shape PASSED [ 69%]
tests/test_report_json_store.py::test_format_legacy_message_chunks_defaults_to_3500_char_limit PASSED [ 69%]
tests/test_report_json_store.py::test_json_util_unsent_local_json_keeps_legacy_chunk_text PASSED [ 70%]
tests/test_report_json_store.py::test_append_report_if_new_writes_once PASSED [ 70%]
tests/test_report_json_store.py::test_json_util_save_data_to_local_json_keeps_legacy_return_and_payload PASSED [ 70%]
tests/test_report_json_store.py::test_select_unsent_reports_filters_date_sent_and_firm PASSED [ 70%]
tests/test_report_json_store.py::test_mark_reports_sent_for_date_updates_only_target_date PASSED [ 71%]
tests/test_report_payload_contract.py::test_scraper_aliases_are_mapped_to_physical_db_fields PASSED [ 71%]
tests/test_report_payload_contract.py::test_ds_empty_telegram_url_is_preserved_for_internal_share_trigger PASSED [ 71%]
tests/test_report_payload_contract.py::test_legacy_save_time_is_an_explicit_artifact_adapter PASSED [ 72%]
tests/test_report_payload_contract.py::test_market_type_is_classified_at_the_shared_payload_boundary[3-16-AMD(AMD.US): FY 2Q26 Review-KR-GLOBAL] PASSED [ 72%]
tests/test_report_payload_contract.py::test_market_type_is_classified_at_the_shared_payload_boundary[3-15-\uae00\ub85c\ubc8c \uc0b0\uc5c5 \uc804\ub9dd-KR-GLOBAL] PASSED [ 72%]
tests/test_report_payload_contract.py::test_market_type_is_classified_at_the_shared_payload_boundary[3-16-\uc0bc\uc131\uc804\uc790(005930.KS): \ud574\uc678 \uacbd\uc7c1\uc0ac \ube44\uad50-KR-GLOBAL] PASSED [ 72%]
tests/test_report_payload_contract.py::test_market_type_is_classified_at_the_shared_payload_boundary[10-3-NVIDIA(NVDA.US): earnings-KR-GLOBAL] PASSED [ 73%]
tests/test_report_payload_contract.py::test_market_type_is_classified_at_the_shared_payload_boundary[10-3-\uc0bc\uc131\uc804\uc790(005930.KS): earnings-US-GLOBAL] PASSED [ 73%]
tests/test_report_payload_contract.py::test_market_type_is_classified_at_the_shared_payload_boundary[1-0-\uad6d\ub0b4 \uc0b0\uc5c5 \uc804\ub9dd-KR-KR] PASSED [ 73%]
tests/test_report_payload_contract.py::test_market_type_is_classified_at_the_shared_payload_boundary[1-3-\ud574\uc678\uc8fc\uc2dd \uc8fc\uac04\uc804\ub7b5-KR-GLOBAL] PASSED [ 74%]
tests/test_report_payload_contract.py::test_strict_artifact_schema_rejects_missing_fields[item0-missing report_unique_key] PASSED [ 74%]
tests/test_report_payload_contract.py::test_strict_artifact_schema_rejects_missing_fields[item1-invalid report_date] PASSED [ 74%]
tests/test_report_payload_contract.py::test_strict_artifact_schema_rejects_missing_fields[item2-missing firm_nm] PASSED [ 74%]
tests/test_scheduler_ga_broadcast.py::test_process_ga_file_retries_empty_result_without_writing_to_db PASSED [ 75%]
tests/test_scheduler_ga_broadcast.py::test_process_ga_file_retries_recent_partial_json PASSED [ 75%]
tests/test_scheduler_ga_broadcast.py::test_broadcast_ga_reports_success PASSED [ 75%]
tests/test_scheduler_ga_broadcast.py::test_broadcast_ga_reports_partial_failure PASSED [ 75%]
tests/test_scheduler_ga_broadcast.py::test_broadcast_ga_reports_filters_unresolved_dbfi PASSED [ 76%]
tests/test_scheduler_process_lifecycle.py::test_scraper_process_uses_isolated_group_and_timeout <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scheduler_process_lifecycle.py PASSED [ 76%]
tests/test_scheduler_process_lifecycle.py::test_timeout_terminates_process_group_and_reaps <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scheduler_process_lifecycle.py PASSED [ 76%]
tests/test_scheduler_process_lifecycle.py::test_invalid_timeout_uses_safe_default <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scheduler_process_lifecycle.py PASSED [ 77%]
tests/test_scraper_error_logging.py::test_call_async_scraper_logs_exception_preserves_return PASSED [ 77%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.LS_0-LS_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 77%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.ShinHanInvest_1-ShinHanInvest_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 77%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.NHQV_2-NHQV_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 78%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.HANA_3-HANA_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 78%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.KBsec_4-KB_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 78%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.Samsung_5-Samsung_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 79%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.Sangsanginib_6-Sangsanginib_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 79%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.Shinyoung_7-Shinyoung_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 79%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.Miraeasset_8-Miraeasset_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 79%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.Hmsec_9-Hmsec_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 80%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.Kiwoom_10-Kiwoom_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 80%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.DS_11-DS_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 80%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.eugenefn_12-eugene_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 80%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.Koreainvestment_13-Koreainvestment_selenium_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 81%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.DAOL_14-DAOL_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 81%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.TOSSinvest_15-TOSSinvest_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 81%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.Leading_16-Leading_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 82%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.Daeshin_17-Daeshin_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 82%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.iMfnsec_18-iMfnsec_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 82%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.DBfi_19-DBfi_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 82%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.MERITZ_20-MERITZ_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 83%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.Hanwhawm_21-Hanwha_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 83%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.Hygood_22-Hanyang_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 83%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.BNKfn_23-BNK_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 83%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.Kyobo_24-Kyobo_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 84%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.IBKs_25-IBK_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 84%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.SKS_26-Sks_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 84%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.Yuanta_27-Yuanta_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 85%]
tests/test_scraper_imports.py::test_scraper_module_imports[modules.Heungkuk_28-Heungkuk_checkNewArticle] <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_scraper_imports.py PASSED [ 85%]
tests/test_sec_reports_manager.py::test_insert_includes_legacy_and_canonical_keys PASSED [ 85%]
tests/test_sec_reports_manager.py::test_insert_preserves_legacy_artifact_save_time PASSED [ 85%]
tests/test_sec_reports_manager.py::test_insert_persists_site_article_text_without_overwriting_with_empty PASSED [ 86%]
tests/test_sec_reports_manager.py::test_mark_reports_sent_marks_is_sent_and_legacy_main_channel_flag PASSED [ 86%]
tests/test_sec_reports_manager.py::test_save_article_text_only_fills_an_empty_field PASSED [ 86%]
tests/test_sec_reports_manager.py::test_update_telegram_url_accepts_pdf_file_url_alias PASSED [ 87%]
tests/test_sec_reports_manager.py::test_daily_update_data_delegates_send_status_to_mark_reports_sent PASSED [ 87%]
tests/test_sec_reports_manager.py::test_select_reports_ready_for_telegram_requires_dbfi_streamdocs_pdf PASSED [ 87%]
tests/test_sec_reports_manager.py::test_keyword_fetch_requires_dbfi_streamdocs_pdf PASSED [ 87%]
tests/test_sec_reports_manager.py::test_dbfi_ready_condition_blocks_dbfi_when_prefix_missing PASSED [ 88%]
tests/test_sec_reports_manager.py::test_duplicate_reset_does_not_mutate_send_status PASSED [ 88%]
tests/test_shinhan_core.py::test_canonical_shinhan_url_normalizes_legacy_domain_protocol_and_path PASSED [ 88%]
tests/test_shinhan_core.py::test_shinhan_mobile_item_keeps_detail_url_and_summary PASSED [ 88%]
tests/test_site_summary_fields.py::test_hmsec_keeps_contents_from_list_api PASSED [ 89%]
tests/test_site_summary_fields.py::test_shinyoung_keeps_summary_from_list_api PASSED [ 89%]
tests/test_sks_core.py::test_normalize_date_accepts_supported_formats PASSED [ 89%]
tests/test_sks_core.py::test_normalize_date_rejects_blank_and_invalid_dates PASSED [ 90%]
tests/test_sks_core.py::test_extract_report_date_uses_configured_key_first PASSED [ 90%]
tests/test_sks_core.py::test_extract_report_date_falls_back_to_pdf_filename PASSED [ 90%]
tests/test_sks_core.py::test_extract_report_date_does_not_use_unrelated_digits PASSED [ 90%]
tests/test_standalone_all_scraper.py::test_select_target_firms_default_includes_ga_and_ls PASSED [ 91%]
tests/test_standalone_all_scraper.py::test_select_target_firms_server_only_excludes_ga_standalones PASSED [ 91%]
tests/test_standalone_all_scraper.py::test_select_target_firms_explicit_firms_overrides_filters PASSED [ 91%]
tests/test_standalone_all_scraper.py::test_sync_scraper_timeout_terminates_worker PASSED [ 91%]
tests/test_standalone_all_scraper.py::test_sync_scraper_rejects_scalar_result PASSED [ 92%]
tests/test_standalone_runner.py::test_run_env_scraper_outputs_json PASSED [ 92%]
tests/test_standalone_runner.py::test_run_env_scraper_accepts_plain_url_list PASSED [ 92%]
tests/test_standalone_runner.py::test_run_env_scraper_rejects_list_when_full_config_required PASSED [ 93%]
tests/test_standalone_runner.py::test_run_env_scraper_reports_missing_config_key PASSED [ 93%]
tests/test_standalone_runner.py::test_run_env_scraper_reports_unhandled_exception PASSED [ 93%]
tests/test_standalone_runner.py::test_config_guard_normalizes_urls_and_requires_keys PASSED [ 93%]
tests/test_telegram_send_audit.py::TestMarkReportsSentSafety::test_default_matches_report_id_only PASSED [ 94%]
tests/test_telegram_send_audit.py::TestMarkReportsSentSafety::test_match_by_url_includes_or_condition PASSED [ 94%]
tests/test_telegram_send_audit.py::TestSelectReportsReadyForTelegram::test_url_condition_in_send_query PASSED [ 94%]
tests/test_telegram_send_audit.py::TestSelectReportsReadyForTelegram::test_hana_ready_row_shape_is_allowed_by_query PASSED [ 95%]
tests/test_telegram_send_audit.py::TestTelegramMessageChunks::test_chunks_keep_exact_rows_for_marking PASSED [ 95%]
tests/test_telegram_send_audit.py::TestTelegramMessageChunks::test_chunks_split_rows_with_message_limit PASSED [ 95%]
tests/test_telegram_send_audit.py::TestTelegramMessageChunks::test_chunks_escape_parentheses_in_markdown_links PASSED [ 95%]
tests/test_telegram_send_audit.py::TestTelegramMessageChunks::test_chunks_use_dbfi_telegram_url_for_links PASSED [ 96%]
tests/test_telegram_send_audit.py::TestTelegramMessageChunks::test_chunks_use_dbfi_telegram_url_only_no_pdf_fallback PASSED [ 96%]
tests/test_telegram_send_audit.py::TestTelegramMessageChunks::test_chunks_dbfi_empty_telegram_url_shows_no_link PASSED [ 96%]
tests/test_telegram_send_audit.py::test_daily_send_report_marks_only_successful_chunks PASSED [ 96%]
tests/test_telegram_send_audit.py::test_sync_scraped_reports_normalizes_dedupes_inserts_and_clears PASSED [ 97%]
tests/test_telegram_send_audit.py::test_scraped_report_helpers_normalize_and_dedupe PASSED [ 97%]
tests/test_toss_error_context.py::test_scrape_toss_logs_error_preserves_return PASSED [ 97%]
tests/test_validate_scrape_result.py::test_manifest_allow_empty_returns_success PASSED [ 98%]
tests/test_validate_scrape_result.py::test_manifest_require_non_empty_rejects_empty PASSED [ 98%]
tests/test_validate_scrape_result.py::test_unknown_firm_fails PASSED     [ 98%]
tests/test_validate_scrape_result.py::test_missing_firm_name_fails_schema_validation PASSED [ 98%]
tests/test_validate_scrape_result.py::test_existing_workflow_filename_resolves_firm PASSED [ 99%]
tests/test_validate_scrape_result.py::test_workflow_validators_use_uv_environment PASSED [ 99%]
tests/test_watchdog_external_failure_budget.py::test_ls_marks_warp_unavailable_after_retry_budget <- ../../../../../../../tmp/ssh-reports-watchdog-fix/tests/test_watchdog_external_failure_budget.py PASSED [ 99%]
tests/test_yuanta_error_context.py::test_yuanta_request_failure_logs_and_returns_partial PASSED [100%]

============================= 362 passed in 8.92s ============================== (362 passed)\n- Production read-only recheck: Daeshin returned 50 rows; LS WARP home request returned HTTP 200.