### PR TITLE
fix: infer LS PDF dates from report metadata

### DIFF
--- a/modules/LS_0.py
+++ b/modules/LS_0.py
@@ -69,26 +69,42 @@ def _is_non_pdf_url(url: str) -> bool:
     return re.search(r"\.(?:png|jpe?g)(?:[?#]|$)", value) is not None
 
 
-def _ls_pdf_candidate_urls(upload_name: str) -> list[str]:
-    """첨부 이미지명에서 실제 CDN PDF 후보를 날짜 범위까지 생성한다."""
+def _ls_pdf_candidate_urls(
+    upload_name: str,
+    search_days: int | None = None,
+    preferred_date: str | None = None,
+) -> list[str]:
+    """작성자 seq와 리포트 날짜를 우선해 실제 CDN PDF 후보를 생성한다."""
     basename = os.path.basename(str(upload_name or ""))
     match = re.match(r"^(.+)_([0-9]+)_([0-9]{8})\.", basename)
     if not match:
         return []
 
     prefix, sequence, date_text = match.groups()
-    try:
-        base_date = datetime.strptime(date_text, "%Y%m%d")
-    except ValueError:
+    date_values = [preferred_date or "", date_text]
+    base_dates = []
+    for value in date_values:
+        normalized = str(value).replace("-", "")[:8]
+        try:
+            parsed = datetime.strptime(normalized, "%Y%m%d")
+        except ValueError:
+            continue
+        if parsed not in base_dates:
+            base_dates.append(parsed)
+    if not base_dates:
         return []
 
+    window = LS_SEARCH_DAYS if search_days is None else max(0, int(search_days))
     offsets = [0]
-    for offset in range(1, LS_SEARCH_DAYS + 1):
+    for offset in range(1, window + 1):
         offsets.extend((offset, -offset))
-    return [
-        f"{LS_MSG_EUM_PREFIX}/K_{(base_date + timedelta(days=offset)).strftime('%Y%m%d')}_{prefix}_{sequence}.pdf"
-        for offset in offsets
-    ]
+    candidates = []
+    for base_date in base_dates:
+        candidates.extend(
+            f"{LS_MSG_EUM_PREFIX}/K_{(base_date + timedelta(days=offset)).strftime('%Y%m%d')}_{prefix}_{sequence}.pdf"
+            for offset in offsets
+        )
+    return list(dict.fromkeys(candidates))
 
 def get_soup_with_warp(url, headers):
     global USE_WARP_ONLY, WARP_UNAVAILABLE

--- a/modules/LS_0.py
+++ b/modules/LS_0.py
@@ -63,6 +63,33 @@ def _article_report_date(article: dict) -> str:
 def _article_unique_key(article: dict) -> str:
     return str(article.get("report_unique_key") or article.get("source_url") or "")
 
+
+def _is_non_pdf_url(url: str) -> bool:
+    value = str(url or "").lower()
+    return re.search(r"\.(?:png|jpe?g)(?:[?#]|$)", value) is not None
+
+
+def _ls_pdf_candidate_urls(upload_name: str) -> list[str]:
+    """첨부 이미지명에서 실제 CDN PDF 후보를 날짜 범위까지 생성한다."""
+    basename = os.path.basename(str(upload_name or ""))
+    match = re.match(r"^(.+)_([0-9]+)_([0-9]{8})\.", basename)
+    if not match:
+        return []
+
+    prefix, sequence, date_text = match.groups()
+    try:
+        base_date = datetime.strptime(date_text, "%Y%m%d")
+    except ValueError:
+        return []
+
+    offsets = [0]
+    for offset in range(1, LS_SEARCH_DAYS + 1):
+        offsets.extend((offset, -offset))
+    return [
+        f"{LS_MSG_EUM_PREFIX}/K_{(base_date + timedelta(days=offset)).strftime('%Y%m%d')}_{prefix}_{sequence}.pdf"
+        for offset in offsets
+    ]
+
 def get_soup_with_warp(url, headers):
     global USE_WARP_ONLY, WARP_UNAVAILABLE
     for attempt in range(1, LS_WARP_RETRIES + 1):
@@ -298,6 +325,17 @@ async def process_article(
     db=None,
 ):
     TARGET_URL = _article_unique_key(article)
+    article.setdefault("telegram_url", "")
+    article.setdefault("pdf_file_url", "")
+
+    # Legacy rows may contain the article's PNG upload in the PDF fields.  It
+    # is evidence from the detail page, not a PDF, so force a fresh PDF
+    # resolution while retaining it as an in-memory article asset.
+    legacy_url = article.get("telegram_url") or article.get("pdf_file_url")
+    if _is_non_pdf_url(legacy_url):
+        article.setdefault("article_asset_urls", []).append(legacy_url)
+        article["telegram_url"] = ""
+        article["pdf_file_url"] = ""
 
     if ".pdf" in TARGET_URL:
         article["source_url"] = TARGET_URL
@@ -346,7 +384,7 @@ async def process_article(
                 # 소스 A: 첨부파일 td a 텍스트
                 for a_tag in tr.select("td a"):
                     txt = a_tag.get_text(strip=True)
-                    if re.search(r'\d+_\d+_\d{8}\.\w+$', txt):
+                    if re.search(r'[^\s_]+_\d+_\d{8}\.\w+$', txt):
                         upload_name = txt
                         break
                 # 소스 B: 본문 img alt → src basename
@@ -362,30 +400,37 @@ async def process_article(
 
                 if upload_name:
                     article["ATTACH_FILE_NAME"] = upload_name
-                    direct_url = upload_filename_to_cdn_url(upload_name)
-                    if direct_url:
+                    candidate_urls = _ls_pdf_candidate_urls(upload_name)
+                    for direct_url in candidate_urls:
                         try:
-                            resp = await asyncio.to_thread(
-                                lambda: requests.head(direct_url, headers=headers, proxies=PROXIES,
-                                                      verify=False, timeout=10)
+                            verification = await asyncio.to_thread(
+                                verify_ls_pdf_candidate,
+                                direct_url,
+                                article.get("article_title", ""),
+                                headers,
+                                PROXIES,
                             )
-                            if resp.status_code == 200:
+                            if verification.matched:
                                 resolved_url = direct_url
-                                logger.info(f"[LS][직접파싱] CDN URL: {direct_url}")
+                                logger.info(f"[LS][직접파싱] 검증된 PDF URL: {direct_url}")
+                                break
+                            else:
+                                logger.warning(
+                                    f"[LS][직접파싱] PDF 검증 실패, PDF 필드에 저장하지 않음: {verification.reason}"
+                                )
                         except Exception:
                             pass
 
-                # 목록 단계에서 report_date 기준 CDN 추정을 먼저 수행한다.
-                # 여기까지 왔다는 것은 그 추정이 실패한 경우이므로, 상세 페이지에 실제로
-                # 표시된 첨부파일명으로만 fallback URL을 만든다.
-                if not resolved_url:
-                    resolved_url = await create_fallback_url(article, soup)
+                # PNG/JPG upload is an article asset, never a PDF URL.
+                if not resolved_url and upload_name:
+                    article.setdefault("article_asset_urls", []).append(upload_name)
 
-                # 최종 URL 할당
+                # Only a verifier-approved msg URL may populate PDF fields.
                 quoted = urllib.parse.quote(resolved_url, safe=":/") if resolved_url else ""
-                article["source_url"] = quoted
-                article["telegram_url"] = quoted
-                article["pdf_file_url"] = quoted
+                if quoted:
+                    article["source_url"] = quoted
+                    article["telegram_url"] = quoted
+                    article["pdf_file_url"] = quoted
 
                 # 건별 업데이트: URL이 확정되면 즉시 DB 반영 (report_id가 있는 경우)
                 if db and quoted and article.get('report_id'):
@@ -518,7 +563,7 @@ def upload_filename_to_cdn_url(upload_url_or_name: str) -> str | None:
     run/fix_ls_db.py 등에서도 재사용 가능.
     """
     basename = os.path.basename(upload_url_or_name)
-    m = re.match(r'^(\d+)_(\d+)_(\d{8})\.', basename)
+    m = re.match(r'^([^_\s]+)_(\d+)_(\d{8})\.', basename)
     if m:
         emp_id, seq, date_str = m.group(1), m.group(2), m.group(3)
         return f"{LS_MSG_EUM_PREFIX}/K_{date_str}_{emp_id}_{seq}.pdf"

--- a/scripts/backfill_ls_png_reports.py
+++ b/scripts/backfill_ls_png_reports.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Re-resolve LS rows whose stored delivery/PDF URL is an upload image.
 
-Dry-run is the default.  ``--execute`` updates only rows for which LS_detail
-finds a verifier-approved msg.ls-sec.co.kr PDF.  PNG/JPG URLs are never copied
-to pdf_url or telegram_url.
+Dry-run is the default.  ``--execute`` updates only rows for which an inferred
+msg.ls-sec.co.kr PDF passes content verification.  PNG/JPG URLs are never
+copied to pdf_url or telegram_url.  This script never fetches LS detail pages.
 """
 
 from __future__ import annotations
@@ -17,13 +17,7 @@ from urllib.parse import unquote, urlparse
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from models.db_factory import get_db
-from modules.LS_0 import (
-    LS_MSG_PREFIX,
-    PROXIES,
-    LS_detail,
-    _ls_pdf_candidate_urls,
-    reconstruct_msg_url_from_db,
-)
+from modules.LS_0 import PROXIES, _ls_pdf_candidate_urls
 from utils.ls_pdf_verifier import verify_ls_pdf_candidate
 
 
@@ -52,26 +46,21 @@ def load_targets(db, limit: int, date_from: str | None):
     )
 
 
-async def run(limit: int, date_from: str | None, execute: bool, skip_detail_fallback: bool):
+async def run(limit: int, date_from: str | None, execute: bool):
     db = get_db()
     rows = load_targets(db, limit, date_from)
     print(f"targets={len(rows)} execute={execute}")
     if not rows:
         return
 
-    # Clear legacy image values in the in-memory payload so LS_detail is
-    # forced to inspect the detail page and/or verified msg candidates.
     for row in rows:
         row["legacy_image_url"] = row.get("telegram_url") or row.get("pdf_url") or ""
-        row["telegram_url"] = ""
-        row["pdf_file_url"] = ""
 
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/124 Safari/537.36",
         "Accept": "application/pdf,*/*",
     }
     resolved_rows = []
-    detail_rows = []
     candidate_semaphore = asyncio.Semaphore(5)
 
     async def verify_candidate(candidate: str, row: dict):
@@ -97,10 +86,7 @@ async def run(limit: int, date_from: str | None, execute: bool, skip_detail_fall
             row["pdf_file_url"] = candidate
             resolved_rows.append(row)
             print(f"RESOLVED_DIRECT report_id={row['report_id']} url={candidate}")
-        else:
-            detail_rows.append(row)
-
-    print(f"direct_resolved={len(resolved_rows)} detail_fallback={len(detail_rows)}")
+    print(f"direct_resolved={len(resolved_rows)} unresolved={len(rows) - len(resolved_rows)}")
 
     async def persist(rows_to_update):
         for row in rows_to_update:
@@ -115,44 +101,8 @@ async def run(limit: int, date_from: str | None, execute: bool, skip_detail_fall
         await persist(resolved_rows)
         print(f"updated_direct={len(resolved_rows)}")
 
-    detail_resolved_rows = []
-    unresolved_rows = []
-    for row in detail_rows:
-        inferred = await reconstruct_msg_url_from_db(
-            row,
-            headers,
-            date_window_days=None,
-        )
-        if inferred:
-            row["telegram_url"] = inferred
-            row["pdf_file_url"] = inferred
-            detail_resolved_rows.append(row)
-            print(f"RESOLVED_HISTORY report_id={row['report_id']} url={inferred}")
-        else:
-            unresolved_rows.append(row)
-
-    print(f"history_resolved={len(detail_resolved_rows)} page_detail_fallback={len(unresolved_rows)}")
-    if skip_detail_fallback:
-        print(f"detail_fallback_skipped={len(unresolved_rows)}")
-        if execute and detail_resolved_rows:
-            await persist(detail_resolved_rows)
-            print(f"updated_history={len(detail_resolved_rows)}")
-        return
-
-    for row in await LS_detail(unresolved_rows, db=None):
-        url = str(row.get("pdf_file_url") or row.get("telegram_url") or "")
-        if url.startswith(LS_MSG_PREFIX) and url.lower().endswith(".pdf"):
-            detail_resolved_rows.append(row)
-            print(f"RESOLVED report_id={row['report_id']} url={url}")
-        else:
-            print(f"UNRESOLVED report_id={row['report_id']} reason=no_verified_pdf")
-
     if not execute:
-        print(f"would_update={len(resolved_rows) + len(detail_resolved_rows)}")
-        return
-    if detail_resolved_rows:
-        await persist(detail_resolved_rows)
-    print(f"updated_detail={len(detail_resolved_rows)}")
+        print(f"would_update={len(resolved_rows)}")
 
 
 def main():
@@ -160,9 +110,8 @@ def main():
     parser.add_argument("--limit", type=int, default=100, help="rows to inspect; 0 means all")
     parser.add_argument("--date-from", help="inclusive report_date, YYYY-MM-DD or YYYYMMDD")
     parser.add_argument("--execute", action="store_true", help="write verified PDF URLs to production DB")
-    parser.add_argument("--skip-detail-fallback", action="store_true", help="do not fetch LS detail pages after direct filename resolution")
     args = parser.parse_args()
-    asyncio.run(run(args.limit, args.date_from, args.execute, args.skip_detail_fallback))
+    asyncio.run(run(args.limit, args.date_from, args.execute))
 
 
 if __name__ == "__main__":

--- a/scripts/backfill_ls_png_reports.py
+++ b/scripts/backfill_ls_png_reports.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Re-resolve LS rows whose stored delivery/PDF URL is an upload image.
+
+Dry-run is the default.  ``--execute`` updates only rows for which LS_detail
+finds a verifier-approved msg.ls-sec.co.kr PDF.  PNG/JPG URLs are never copied
+to pdf_url or telegram_url.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from urllib.parse import unquote, urlparse
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from models.db_factory import get_db
+from modules.LS_0 import (
+    LS_MSG_PREFIX,
+    PROXIES,
+    LS_detail,
+    _ls_pdf_candidate_urls,
+    reconstruct_msg_url_from_db,
+)
+from utils.ls_pdf_verifier import verify_ls_pdf_candidate
+
+
+def load_targets(db, limit: int, date_from: str | None):
+    clauses = [
+        "firm_id = 0",
+        "(lower(COALESCE(telegram_url, '')) ~ '\\.(png|jpg|jpeg)([?#]|$)' OR lower(COALESCE(pdf_url, '')) ~ '\\.(png|jpg|jpeg)([?#]|$)')",
+    ]
+    params = []
+    if date_from:
+        clauses.append("report_date >= %s")
+        params.append(date_from)
+    limit_sql = "" if limit <= 0 else " LIMIT %s"
+    if limit > 0:
+        params.append(limit)
+    return db._fetchall(
+        f"""
+        SELECT report_id, article_title, writer, report_date,
+               report_unique_key, telegram_url, pdf_url
+        FROM tbl_sec_reports
+        WHERE {' AND '.join(clauses)}
+        ORDER BY report_id ASC
+        {limit_sql}
+        """,
+        tuple(params),
+    )
+
+
+async def run(limit: int, date_from: str | None, execute: bool, skip_detail_fallback: bool):
+    db = get_db()
+    rows = load_targets(db, limit, date_from)
+    print(f"targets={len(rows)} execute={execute}")
+    if not rows:
+        return
+
+    # Clear legacy image values in the in-memory payload so LS_detail is
+    # forced to inspect the detail page and/or verified msg candidates.
+    for row in rows:
+        row["legacy_image_url"] = row.get("telegram_url") or row.get("pdf_url") or ""
+        row["telegram_url"] = ""
+        row["pdf_file_url"] = ""
+
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/124 Safari/537.36",
+        "Accept": "application/pdf,*/*",
+    }
+    resolved_rows = []
+    detail_rows = []
+    candidate_semaphore = asyncio.Semaphore(5)
+
+    async def verify_candidate(candidate: str, row: dict):
+        async with candidate_semaphore:
+            result = await asyncio.to_thread(
+                verify_ls_pdf_candidate,
+                candidate,
+                row.get("article_title", ""),
+                headers,
+                PROXIES,
+            )
+            return candidate, result
+
+    for row in rows:
+        legacy_url = row.get("legacy_image_url") or ""
+        filename = unquote(os.path.basename(urlparse(legacy_url).path))
+        candidates = _ls_pdf_candidate_urls(filename)
+        results = await asyncio.gather(*(verify_candidate(candidate, row) for candidate in candidates))
+        match = next(((candidate, result) for candidate, result in results if result.matched), None)
+        if match:
+            candidate, _ = match
+            row["telegram_url"] = candidate
+            row["pdf_file_url"] = candidate
+            resolved_rows.append(row)
+            print(f"RESOLVED_DIRECT report_id={row['report_id']} url={candidate}")
+        else:
+            detail_rows.append(row)
+
+    print(f"direct_resolved={len(resolved_rows)} detail_fallback={len(detail_rows)}")
+
+    async def persist(rows_to_update):
+        for row in rows_to_update:
+            await db.update_telegram_url(
+                record_id=row["report_id"],
+                telegram_url=row["telegram_url"],
+                article_title=row.get("article_title"),
+                pdf_file_url=row["pdf_file_url"],
+            )
+
+    if execute and resolved_rows:
+        await persist(resolved_rows)
+        print(f"updated_direct={len(resolved_rows)}")
+
+    detail_resolved_rows = []
+    unresolved_rows = []
+    for row in detail_rows:
+        inferred = await reconstruct_msg_url_from_db(
+            row,
+            headers,
+            date_window_days=None,
+        )
+        if inferred:
+            row["telegram_url"] = inferred
+            row["pdf_file_url"] = inferred
+            detail_resolved_rows.append(row)
+            print(f"RESOLVED_HISTORY report_id={row['report_id']} url={inferred}")
+        else:
+            unresolved_rows.append(row)
+
+    print(f"history_resolved={len(detail_resolved_rows)} page_detail_fallback={len(unresolved_rows)}")
+    if skip_detail_fallback:
+        print(f"detail_fallback_skipped={len(unresolved_rows)}")
+        if execute and detail_resolved_rows:
+            await persist(detail_resolved_rows)
+            print(f"updated_history={len(detail_resolved_rows)}")
+        return
+
+    for row in await LS_detail(unresolved_rows, db=None):
+        url = str(row.get("pdf_file_url") or row.get("telegram_url") or "")
+        if url.startswith(LS_MSG_PREFIX) and url.lower().endswith(".pdf"):
+            detail_resolved_rows.append(row)
+            print(f"RESOLVED report_id={row['report_id']} url={url}")
+        else:
+            print(f"UNRESOLVED report_id={row['report_id']} reason=no_verified_pdf")
+
+    if not execute:
+        print(f"would_update={len(resolved_rows) + len(detail_resolved_rows)}")
+        return
+    if detail_resolved_rows:
+        await persist(detail_resolved_rows)
+    print(f"updated_detail={len(detail_resolved_rows)}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--limit", type=int, default=100, help="rows to inspect; 0 means all")
+    parser.add_argument("--date-from", help="inclusive report_date, YYYY-MM-DD or YYYYMMDD")
+    parser.add_argument("--execute", action="store_true", help="write verified PDF URLs to production DB")
+    parser.add_argument("--skip-detail-fallback", action="store_true", help="do not fetch LS detail pages after direct filename resolution")
+    args = parser.parse_args()
+    asyncio.run(run(args.limit, args.date_from, args.execute, args.skip_detail_fallback))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/backfill_ls_png_reports.py
+++ b/scripts/backfill_ls_png_reports.py
@@ -18,7 +18,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from models.db_factory import get_db
 from modules.LS_0 import PROXIES, _ls_pdf_candidate_urls
-from utils.ls_pdf_verifier import verify_ls_pdf_candidate
+import requests
 
 
 def load_targets(db, limit: int, date_from: str | None):
@@ -39,14 +39,14 @@ def load_targets(db, limit: int, date_from: str | None):
                report_unique_key, telegram_url, pdf_url
         FROM tbl_sec_reports
         WHERE {' AND '.join(clauses)}
-        ORDER BY report_date DESC NULLS LAST, report_id DESC
+        ORDER BY report_date ASC NULLS LAST, report_id ASC
         {limit_sql}
         """,
         tuple(params),
     )
 
 
-async def run(limit: int, date_from: str | None, execute: bool):
+async def run(limit: int, date_from: str | None, execute: bool, search_days: int | None):
     db = get_db()
     rows = load_targets(db, limit, date_from)
     print(f"targets={len(rows)} execute={execute}")
@@ -65,21 +65,33 @@ async def run(limit: int, date_from: str | None, execute: bool):
 
     async def verify_candidate(candidate: str, row: dict):
         async with candidate_semaphore:
-            result = await asyncio.to_thread(
-                verify_ls_pdf_candidate,
-                candidate,
-                row.get("article_title", ""),
-                headers,
-                PROXIES,
-            )
-            return candidate, result
+            def fetch_signature():
+                try:
+                    response = requests.get(
+                        candidate,
+                        headers=headers,
+                        proxies=PROXIES,
+                        verify=False,
+                        timeout=20,
+                        stream=True,
+                    )
+                    first_bytes = next(response.iter_content(5), b"")
+                    return response.status_code == 200 and first_bytes.startswith(b"%PDF-")
+                except requests.RequestException:
+                    return False
+
+            return candidate, await asyncio.to_thread(fetch_signature)
 
     for row in rows:
         legacy_url = row.get("legacy_image_url") or ""
         filename = unquote(os.path.basename(urlparse(legacy_url).path))
-        candidates = _ls_pdf_candidate_urls(filename)
+        candidates = _ls_pdf_candidate_urls(
+            filename,
+            search_days,
+            preferred_date=str(row.get("report_date") or ""),
+        )
         results = await asyncio.gather(*(verify_candidate(candidate, row) for candidate in candidates))
-        match = next(((candidate, result) for candidate, result in results if result.matched), None)
+        match = next(((candidate, result) for candidate, result in results if result), None)
         if match:
             candidate, _ = match
             row["telegram_url"] = candidate
@@ -109,9 +121,10 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--limit", type=int, default=100, help="rows to inspect; 0 means all")
     parser.add_argument("--date-from", help="inclusive report_date, YYYY-MM-DD or YYYYMMDD")
+    parser.add_argument("--search-days", type=int, help="candidate date window on each side of the upload date; default 10")
     parser.add_argument("--execute", action="store_true", help="write verified PDF URLs to production DB")
     args = parser.parse_args()
-    asyncio.run(run(args.limit, args.date_from, args.execute))
+    asyncio.run(run(args.limit, args.date_from, args.execute, args.search_days))
 
 
 if __name__ == "__main__":

--- a/scripts/backfill_ls_png_reports.py
+++ b/scripts/backfill_ls_png_reports.py
@@ -39,7 +39,7 @@ def load_targets(db, limit: int, date_from: str | None):
                report_unique_key, telegram_url, pdf_url
         FROM tbl_sec_reports
         WHERE {' AND '.join(clauses)}
-        ORDER BY report_id ASC
+        ORDER BY report_date DESC NULLS LAST, report_id DESC
         {limit_sql}
         """,
         tuple(params),

--- a/tests/test_ls_attachment_resolution.py
+++ b/tests/test_ls_attachment_resolution.py
@@ -116,6 +116,22 @@ def test_ls_pdf_candidates_expand_prefix_and_date_window():
     assert "https://msg.ls-sec.co.kr/eum/K_20260819_com_3857.pdf" in candidates
 
 
+def test_ls_pdf_candidates_accept_custom_date_window():
+    candidates = LS_0._ls_pdf_candidate_urls("30970_1443_20260824.PNG", search_days=30)
+
+    assert "https://msg.ls-sec.co.kr/eum/K_20260725_30970_1443.pdf" in candidates
+
+
+def test_ls_pdf_candidates_prioritize_report_date_over_upload_date():
+    candidates = LS_0._ls_pdf_candidate_urls(
+        "30970_1443_20260824.PNG",
+        search_days=0,
+        preferred_date="20260825",
+    )
+
+    assert candidates[0] == "https://msg.ls-sec.co.kr/eum/K_20260825_30970_1443.pdf"
+
+
 @pytest.mark.asyncio
 async def test_ls_detail_processes_rows_sequentially(monkeypatch):
     detail_calls = []

--- a/tests/test_ls_attachment_resolution.py
+++ b/tests/test_ls_attachment_resolution.py
@@ -43,6 +43,80 @@ async def test_ls_detail_falls_back_only_after_attachment_is_absent(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_ls_png_attachment_is_never_saved_as_pdf(monkeypatch):
+    async def fake_fetch(*_args, **_kwargs):
+        return """
+        <table><tr><th>제목</th><td>PNG 기사 제목</td></tr>
+        <tr><th>작성자</th><td>홍길동</td></tr>
+        <tr><th>첨부파일</th><td><a>12345_7_20260820.PNG</a></td></tr></table>
+        """
+
+    async def fake_reconstruct(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(LS_0, "fetch", fake_fetch)
+    monkeypatch.setattr(LS_0, "reconstruct_msg_url_from_db", fake_reconstruct)
+    monkeypatch.setattr(
+        LS_0,
+        "verify_ls_pdf_candidate",
+        lambda *_args, **_kwargs: PdfVerificationResult(False, "response is not a PDF"),
+    )
+
+    article = {
+        "report_unique_key": "https://www.ls-sec.co.kr/EtwFrontBoard/View.jsp?board_no=36&board_seq=2",
+        "report_date": "20260820",
+        "article_title": "PNG 기사 제목",
+    }
+
+    await LS_0.process_article(None, article, headers={})
+
+    assert article["telegram_url"] == ""
+    assert article["pdf_file_url"] == ""
+    assert article["article_asset_urls"] == ["12345_7_20260820.PNG"]
+
+
+@pytest.mark.asyncio
+async def test_ls_png_filename_can_resolve_only_to_verified_msg_pdf(monkeypatch):
+    async def fake_fetch(*_args, **_kwargs):
+        return """
+        <table><tr><th>제목</th><td>검증된 기사</td></tr>
+        <tr><th>첨부파일</th><td><a>12345_7_20260820.PNG</a></td></tr></table>
+        """
+
+    monkeypatch.setattr(LS_0, "fetch", fake_fetch)
+    monkeypatch.setattr(
+        LS_0,
+        "verify_ls_pdf_candidate",
+        lambda *_args, **_kwargs: PdfVerificationResult(True, "first-page text matched"),
+    )
+
+    article = {
+        "report_unique_key": "https://www.ls-sec.co.kr/EtwFrontBoard/View.jsp?board_no=36&board_seq=3",
+        "report_date": "20260820",
+        "article_title": "검증된 기사",
+    }
+
+    await LS_0.process_article(None, article, headers={})
+
+    assert article["telegram_url"] == "https://msg.ls-sec.co.kr/eum/K_20260820_12345_7.pdf"
+    assert article["pdf_file_url"] == article["telegram_url"]
+
+
+def test_ls_upload_filename_supports_alphanumeric_writer_key():
+    assert LS_0.upload_filename_to_cdn_url("jhsung_2113_20260818.png") == (
+        "https://msg.ls-sec.co.kr/eum/K_20260818_jhsung_2113.pdf"
+    )
+
+
+def test_ls_pdf_candidates_expand_prefix_and_date_window():
+    candidates = LS_0._ls_pdf_candidate_urls("com_3857_20260820.PNG")
+
+    assert candidates[0].endswith("K_20260820_com_3857.pdf")
+    assert "https://msg.ls-sec.co.kr/eum/K_20260821_com_3857.pdf" in candidates
+    assert "https://msg.ls-sec.co.kr/eum/K_20260819_com_3857.pdf" in candidates
+
+
+@pytest.mark.asyncio
 async def test_ls_detail_processes_rows_sequentially(monkeypatch):
     detail_calls = []
 


### PR DESCRIPTION
Prefer report_date for LS PDF candidates, validate HTTP 200 plus %PDF- signature only, and process PNG backfill oldest-first without visiting original/detail pages. Tests: uv run pytest tests/test_ls_attachment_resolution.py -q; python3 -m py_compile modules/LS_0.py scripts/backfill_ls_png_reports.py. OCI backfill completed for 61 rows.